### PR TITLE
Add Module Filter

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/init/fn_onCuratorStart.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/init/fn_onCuratorStart.sqf
@@ -8,48 +8,14 @@
 
 params [["_tree_ctrl", controlNull, [controlNull]]];
 
-private _display_reload = false;
-
 // broadcast safe spawn
 publicVariable "Achilles_fnc_spawn";
 publicVariable "Achilles_fnc_spawn_remote";
 
-// trick to unlock ares/achilles modules for Zeus if mission was not set up properly
-if (!("achilles_modules_f_achilles" in (curatorAddons getAssignedCuratorLogic player))) then
-{
-	private _logic = (createGroup sideLogic) createUnit ["Achilles_Module_Base", [0,0,0], [], 0, "NONE"];
-	_logic = (createGroup sideLogic) createUnit ["Ares_Module_Base", [0,0,0], [], 0, "NONE"];
-
-	// wait until zeus has truly entered the interface
-	waitUntil {sleep 1; !isNull (findDisplay 312)};
-
-	// Wait until Zeus modules are avaiable (e.g. respawns have to be placed before)
-	if (count allMissionObjects "ModuleMPTypeGameMaster_F" > 0) then
-	{
-		waitUntil {sleep 1; missionnamespace getvariable ["BIS_moduleMPTypeGameMaster_init", false]};
-	};
-
-	[[getAssignedCuratorLogic player],
-	{
-		private _curatorModule = _this select 0;
-		_curatorModule addCuratorAddons ["achilles_modules_f_achilles","achilles_modules_f_ares"];
-	}, 2] call Achilles_fnc_spawn;
-
-	// reload interface
-	waitUntil {sleep 1; "achilles_modules_f_achilles" in (curatorAddons getAssignedCuratorLogic player)};
-	cutText ["","BLACK OUT", 0.1,true];
-	uiSleep 0.1;
-	(findDisplay 312) closeDisplay 0;
-	uiSleep 0.1;
-	openCuratorInterface;
-	cutText ["","BLACK IN", 0.1, true];
-	_display_reload = true;
-};
-
 //prevent drawing mines
 if (!(missionnamespace getvariable ["bis_fnc_drawMinefields_active",false])) then
 {
-	missionnamespace setvariable ["bis_fnc_drawMinefields_active",true,true];
+	missionnamespace setvariable ["bis_fnc_drawMinefields_active", true, true];
 };
 
 // Initialize settings variables
@@ -101,5 +67,3 @@ _curatorModule setVariable ["BIS_fnc_curatorAttributesobject",["%ALL"]];
 _curatorModule setVariable ["BIS_fnc_curatorAttributesgroup",["%ALL"]];
 _curatorModule setVariable ["BIS_fnc_curatorAttributeswaypoint",["%ALL"]];
 _curatorModule setVariable ["BIS_fnc_curatorAttributesmarker",["%ALL"]];
-
-_display_reload;

--- a/@AresModAchillesExpansion/addons/functions_f_ares/common/fn_RegisterCustomModule.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_ares/common/fn_RegisterCustomModule.sqf
@@ -52,14 +52,14 @@ if (!_replacedExistingEntry) then
 
 	// Add module to module tree
 	private _ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
-	private _category_list = missionNamespace getVariable ["Ares_category_list", []];
-	_category_list = [_ctrl, _category_list, _categoryName, _moduleDisplayName, _moduleClassName, _index] call Achilles_fnc_AppendToModuleTree;
+	private _categoryList = missionNamespace getVariable ["Ares_category_list", []];
+	_categoryList = [_ctrl, _categoryList, _categoryName, _moduleDisplayName, _moduleClassName] call Achilles_fnc_appendToModuleTree;
 
 	//Sort category and module list
 	_ctrl tvSort [[], false];
 	for "_i" from 0 to ((_ctrl tvCount []) - 1) do {_ctrl tvSort [[_i], false];};
 
 	//get module list
-	_category_list sort true;
-	Ares_category_list = _category_list;
+	_categoryList sort true;
+	Ares_category_list = _categoryList;
 };

--- a/@AresModAchillesExpansion/addons/functions_f_ares/common/fn_RegisterCustomModule.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_ares/common/fn_RegisterCustomModule.sqf
@@ -52,7 +52,8 @@ if (!_replacedExistingEntry) then
 
 	// Add module to module tree
 	private _ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
-	private _category_list = [_ctrl,Ares_category_list,_categoryName,_moduleDisplayName,_moduleClassName,_index] call Achilles_fnc_AppendToModuleTree;
+	private _category_list = missionNamespace getVariable ["Ares_category_list", []];
+	_category_list = [_ctrl, _category_list, _categoryName, _moduleDisplayName, _moduleClassName, _index] call Achilles_fnc_AppendToModuleTree;
 
 	//Sort category and module list
 	_ctrl tvSort [[], false];

--- a/@AresModAchillesExpansion/addons/language_f/stringtable.xml
+++ b/@AresModAchillesExpansion/addons/language_f/stringtable.xml
@@ -6339,6 +6339,12 @@
             </Key>
         </Container>
         <Container name="Settings">
+            <Key ID="STR_AMAE_AVAILABLE_MODULES">
+                <Original>Achilles - Available Modules</Original>
+                <English>Achilles - Available Modules</English>
+                <French>Achilles - Modules disponibles</French>
+                <German>Achilles - Verfügbare Module</German>
+            </Key>
             <Key ID="STR_AMAE_AVAILABLE_FACTIONS">
                 <Original>Achilles - Available Factions</Original>
                 <English>Achilles - Available Factions</English>

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/ACE/cfgVehiclesModulesACE.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/ACE/cfgVehiclesModulesACE.hpp
@@ -9,7 +9,7 @@ class Achilles_ACE_Module_Base : Achilles_Module_Base
 
 class Achilles_ACE_Injury_Module : Achilles_ACE_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_ACE_Injury_Module";
 	displayName = "$STR_AMAE_INJURY";
 	function = "Achilles_fnc_ModuleACEInjury";
@@ -17,7 +17,7 @@ class Achilles_ACE_Injury_Module : Achilles_ACE_Module_Base
 
 class Achilles_ACE_Heal_Module : Achilles_ACE_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_ACE_Heal_Module";
 	displayName = "$STR_AMAE_HEAL";
 	function = "Achilles_fnc_ModuleACEHeal";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Arsenal/cfgVehiclesModulesArsenal.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Arsenal/cfgVehiclesModulesArsenal.hpp
@@ -7,14 +7,14 @@ class Achilles_Arsenal_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Arsenal_AddFull : Achilles_Arsenal_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADD_FULL";
 	function = "Achilles_fnc_ArsenalAddFull";
 };
 
 class Achilles_Module_Arsenal_CreateCustom : Achilles_Arsenal_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ARSENAL_CREATE_CUSTOM";
 	function = "Achilles_fnc_ArsenalCreateCustom";
 	icon = "\achilles\data_f_ares\icons\icon_default.paa";
@@ -23,7 +23,7 @@ class Achilles_Module_Arsenal_CreateCustom : Achilles_Arsenal_Module_Base
 
 class Achilles_Module_Arsenal_CopyToClipboard : Achilles_Arsenal_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_COPY_TO_CLIPBOARD";
 	function = "Achilles_fnc_ArsenalCopyToClipboard";
 	icon = "\achilles\data_f_achilles\icons\icon_object.paa";
@@ -32,7 +32,7 @@ class Achilles_Module_Arsenal_CopyToClipboard : Achilles_Arsenal_Module_Base
 
 class Achilles_Module_Arsenal_Paste : Achilles_Arsenal_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ARSENAL_PASTE";
 	function = "Achilles_fnc_ArsenalPaste";
 	icon = "\achilles\data_f_achilles\icons\icon_object.paa";
@@ -41,7 +41,7 @@ class Achilles_Module_Arsenal_Paste : Achilles_Arsenal_Module_Base
 
 class Achilles_Module_Arsenal_Remove : Achilles_Arsenal_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ARSENAL_REMOVE";
 	function = "Achilles_fnc_ArsenalRemove";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/cfgVehiclesModulesBehaviours.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/cfgVehiclesModulesBehaviours.hpp
@@ -15,7 +15,7 @@ class Enyo_Behaviours_Module_Base : Enyo_Module_Base
 
 class Achilles_Animation_Module : Achilles_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_Animation_Module";
 	displayName = "$STR_AMAE_AMBIENT_ANIMATION";
@@ -24,7 +24,7 @@ class Achilles_Animation_Module : Achilles_Behaviours_Module_Base
 
 class Achilles_Chatter_Module : Achilles_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_Chatter_Module";
 	displayName = "$STR_AMAE_CHATTER";
@@ -33,7 +33,7 @@ class Achilles_Chatter_Module : Achilles_Behaviours_Module_Base
 
 class Achilles_Sit_On_Chair_Module : Achilles_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_Sit_On_Chair_Module";
 	displayName = "$STR_AMAE_SIT_ON_CHAIR";
@@ -44,7 +44,7 @@ class Achilles_Sit_On_Chair_Module : Achilles_Behaviours_Module_Base
 
 class Achilles_Change_Ability_Module : Achilles_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_Change_Ability_Module";
 	displayName = "$STR_AMAE_CHANGE_ABILITIES";
@@ -53,7 +53,7 @@ class Achilles_Change_Ability_Module : Achilles_Behaviours_Module_Base
 
 class Achilles_Change_Altitude_Module : Achilles_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_Change_Altitude_Module";
 	displayName = "$STR_AMAE_CHANGE_ALTITUDE";
@@ -62,7 +62,7 @@ class Achilles_Change_Altitude_Module : Achilles_Behaviours_Module_Base
 
 class Achilles_SuicideBomber_Module : Enyo_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Enyo_SuicideBomber_Module";
 	displayName = "$STR_AMAE_ENYO_SET_SUICIDE_BOMBER";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Buildings/cfgVehiclesModulesBuildings.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Buildings/cfgVehiclesModulesBuildings.hpp
@@ -9,7 +9,7 @@ class Achilles_Buildings_Module_Base : Achilles_Module_Base
 
 class Achilles_Buildings_Destroy_Module : Achilles_Buildings_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Buildings_Destroy_Module";
 	displayName = "$STR_AMAE_DAMAGE_BUILDINGS";
 	function = "Achilles_fnc_BuildingsDestroy";
@@ -17,7 +17,7 @@ class Achilles_Buildings_Destroy_Module : Achilles_Buildings_Module_Base
 
 class Achilles_Buildings_LockDoors_Module : Achilles_Buildings_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Buildings_LockDoors_Module";
 	displayName = "$STR_AMAE_LOCK_DOORS";
 	function = "Achilles_fnc_LockDoors";
@@ -28,7 +28,7 @@ class Achilles_Buildings_LockDoors_Module : Achilles_Buildings_Module_Base
 
 class Achilles_Buildings_ToggleLight_Module : Achilles_Buildings_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Buildings_ToggleLight_Module";
 	displayName = "$STR_AMAE_TOGGLE_LAMPS";
 	function = "Achilles_fnc_ToggleLamps";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/DevTools/cfgVehiclesModulesDevTools.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/DevTools/cfgVehiclesModulesDevTools.hpp
@@ -6,7 +6,7 @@ class Achilles_Dev_Tools_Module_Base : Achilles_Module_Base
 
 class Achilles_Bind_Variable_Module : Achilles_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Bind_Variable_Module";
 	displayName = "$STR_AMAE_BIND_VAR";
 	function = "Achilles_fnc_DevToolsBindVariable";
@@ -16,14 +16,14 @@ class Achilles_Bind_Variable_Module : Achilles_Dev_Tools_Module_Base
 
 class Achilles_Module_Manage_Advanced_Compositions : Achilles_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADVANCED_COMPOSITION";
 	function = "Achilles_fnc_DevTools_manageAdvancedCompositions";
 };
 
 class Achilles_DevTools_ShowInAnimViewer : Achilles_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_DevTools_ShowInAnimViewer";
 	displayName = "$STR_AMAE_SHOW_IN_ANIM_VIEWER";
 	function = "Achilles_fnc_DevToolsShowInAnimViewer";
@@ -33,7 +33,7 @@ class Achilles_DevTools_ShowInAnimViewer : Achilles_Dev_Tools_Module_Base
 
 class Achilles_DevTools_ShowInConfig : Achilles_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_DevTools_ShowInConfig";
 	displayName = "$STR_AMAE_SHOW_IN_CONFIG";
 	function = "Achilles_fnc_DevToolsShowInConfig";
@@ -43,7 +43,7 @@ class Achilles_DevTools_ShowInConfig : Achilles_Dev_Tools_Module_Base
 
 class Achilles_DevTools_FunctionViewer : Achilles_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_DevTools_ShowInConfig";
 	displayName = "$STR_AMAE_FUNCTION_VIEWER";
 	function = "Achilles_fnc_DevToolsFunctionViewer";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Environment/cfgVehiclesModulesEnvironment.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Environment/cfgVehiclesModulesEnvironment.hpp
@@ -6,7 +6,7 @@ class Achilles_Environment_Module_Base : Achilles_Module_Base
 
 class Achilles_Set_Weather_Module : Achilles_Environment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Set_Weather_Module";
 	displayName = "$STR_AMAE_ADVANCED_WEATHER_CHANGE";
 	function = "Achilles_fnc_EnvironmentSetWeatherModule";
@@ -16,7 +16,7 @@ class Achilles_Set_Weather_Module : Achilles_Environment_Module_Base
 
 class Achilles_Set_Date_Module : Achilles_Environment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Set_Date_Module";
 	displayName = "$STR_AMAE_SET_DATE";
 	function = "Achilles_fnc_EnvironmentSetDate";
@@ -26,7 +26,7 @@ class Achilles_Set_Date_Module : Achilles_Environment_Module_Base
 
 class Achilles_Earthquake_Module : Achilles_Environment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Earthquake_Module";
 	displayName = "$STR_AMAE_EARTHQUAKE";
 	function = "Achilles_fnc_EnvironmentEarthquake";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Equipment/cfgVehiclesModulesEquipment.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Equipment/cfgVehiclesModulesEquipment.hpp
@@ -8,7 +8,7 @@ class Achilles_Equipment_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Equipment_Attach_Dettach_Effect : Achilles_Equipment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ATTACH_DETACH_EFFECT";
 	function = "Achilles_fnc_attachDetachEffect";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/cfgVehiclesModulesFireSupport.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/cfgVehiclesModulesFireSupport.hpp
@@ -6,7 +6,7 @@ class Achilles_FireSupport_ModuleBase : Achilles_Module_Base
 
 class Achilles_Suppressive_Fire_Module : Achilles_FireSupport_ModuleBase
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Suppressive_Fire_Module";
 	displayName = "$STR_AMAE_SUPPRESIVE_FIRE";
 	function = "Achilles_fnc_ModuleFireSupportSuppressiveFire";
@@ -17,7 +17,7 @@ class Achilles_Suppressive_Fire_Module : Achilles_FireSupport_ModuleBase
 
 class Achilles_CAS_Module : Achilles_FireSupport_ModuleBase
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_CAS_Module";
 	displayName = "$STR_AMAE_ADVANCED_CAS";
 	function = "Achilles_fnc_ModuleFireSupportCAS";
@@ -28,7 +28,7 @@ class Achilles_CAS_Module : Achilles_FireSupport_ModuleBase
 
 class Achilles_Create_Universal_Target_Module : Achilles_FireSupport_ModuleBase
 {
-    scopeCurator = 2;
+    scopeCurator = 1;
     _generalMacro = "Achilles_Create_Universal_Target_Module";
     displayName = "$STR_AMAE_CREATE_TARGET";
     function = "Achilles_fnc_ModuleFireSupportCreateUniversalTarget";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/MissionFlow/cfgVehiclesModulesMissionFlow.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/MissionFlow/cfgVehiclesModulesMissionFlow.hpp
@@ -6,7 +6,7 @@ class Achilles_Mission_Flow_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Spawn_Intel : Achilles_Mission_Flow_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CREATE_EDIT_INTEL";
 	function = "Achilles_fnc_SpawnCreateEditIntel";
 	icon = "\achilles\data_f_achilles\icons\icon_default_object.paa";
@@ -15,7 +15,7 @@ class Achilles_Module_Spawn_Intel : Achilles_Mission_Flow_Module_Base
 
 class Achilles_Module_Change_Side_Relations : Achilles_Mission_Flow_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CHANGE_SIDE_RELATIONS";
 	function = "Achilles_fnc_changeSideRelations";
 	icon = "\achilles\data_f_ares\icons\icon_default.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Objects/cfgVehiclesModulesObjects.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Objects/cfgVehiclesModulesObjects.hpp
@@ -13,7 +13,7 @@ class Enyo_Objects_Module_Base : Enyo_Module_Base
 
 class Achilles_Toggle_Simulation_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Toggle_Simulation_Module";
 	displayName = "$STR_AMAE_TOGGLE_SIMULATION";
 	function = "Achilles_fnc_ObjectsToggleSimulation";
@@ -22,7 +22,7 @@ class Achilles_Toggle_Simulation_Module : Achilles_Objects_Module_Base
 };
 class Achilles_Attach_To_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Attach_To_Module";
 	displayName = "$STR_AMAE_ATTACH_TO";
 	function = "Achilles_fnc_ObjectsAttachTo";
@@ -31,7 +31,7 @@ class Achilles_Attach_To_Module : Achilles_Objects_Module_Base
 };
 class Achilles_Make_Invincible_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Make_Invincible_Module";
 	displayName = "$STR_AMAE_MAKE_INVINCIBLE";
 	function = "Achilles_fnc_ModuleObjectsMakeInvincible";
@@ -40,7 +40,7 @@ class Achilles_Make_Invincible_Module : Achilles_Objects_Module_Base
 };
 class Achilles_Set_Height_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Set_Height_Module";
 	displayName = "$STR_AMAE_CHANGE_HEIGHT";
 	function = "Achilles_fnc_ObjectsSetHeight";
@@ -49,7 +49,7 @@ class Achilles_Set_Height_Module : Achilles_Objects_Module_Base
 };
 class Achilles_Transfer_Ownership_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Achilles_Transfer_Ownership_Module";
 	displayName = "$STR_AMAE_TRANSFER_OWNERSHIP";
 	function = "Achilles_fnc_ObjectsTransferOwnership";
@@ -58,7 +58,7 @@ class Achilles_Transfer_Ownership_Module : Achilles_Objects_Module_Base
 };
 class Achilles_IED_Module : Enyo_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_IED_Module";
 	displayName = "$STR_AMAE_ENYO_CREATE_IED";
@@ -69,7 +69,7 @@ class Achilles_IED_Module : Enyo_Objects_Module_Base
 
 class Achilles_AddECM_Module : Enyo_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	_generalMacro = "Achilles_AddECM_Module";
 	displayName = "$STR_AMAE_ENYO_ADD_ECM_TO_VEHICLE";
@@ -77,7 +77,7 @@ class Achilles_AddECM_Module : Enyo_Objects_Module_Base
 };
 class Achilles_Module_Rotation : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ROTATION_MODULE";
 	function = "Achilles_fnc_ObjectsRotation";
 	icon = "\achilles\data_f_achilles\icons\icon_rotateObjects.paa";
@@ -85,7 +85,7 @@ class Achilles_Module_Rotation : Achilles_Objects_Module_Base
 };
 class Achilles_Hide_Objects_Module : Achilles_Objects_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_HIDE_OBJECTS";
 	function = "Achilles_fnc_ObjectsHide";
 	icon = "\achilles\data_f_achilles\icons\icon_hideZeus.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Player/cfgVehiclesModulesPlayer.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Player/cfgVehiclesModulesPlayer.hpp
@@ -6,7 +6,7 @@ class Achilles_Player_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Player_Set_Frequencies : Achilles_Player_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SET_FREQUENCIES";
 	function = "Achilles_fnc_PlayerSetFrequencies";
 	icon = "\achilles\data_f_achilles\icons\icon_TFARFreqs.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Reinforcements/cfgVehiclesModulesReinforcements.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Reinforcements/cfgVehiclesModulesReinforcements.hpp
@@ -5,7 +5,7 @@ class Achilles_Reinforcements_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Supply_Drop : Achilles_Reinforcements_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	curatorCanAttach = 1;
 	displayName = "$STR_AMAE_SUPPLY_DROP";
 	function = "Achilles_fnc_ReinforcementsSupplyDrop";

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Replacement/cfgVehiclesModulesReplacement.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Replacement/cfgVehiclesModulesReplacement.hpp
@@ -22,7 +22,7 @@ class Achilles_Module_FireSupport_CASGun : ModuleCASGun_F
 {
 	_generalMacro = "Achilles_Module_FireSupport_CASGun";
 	scope = 1;
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_A3_CfgVehicles_ModuleCAS_F_Arguments_Type_values_Gun";
 	function = "";
 	functionPriority = 1;	// Execution priority, modules with lower number are executed first. 0 is used when the attribute is undefined

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Spawn/cfgVehiclesModulesSpawn.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Spawn/cfgVehiclesModulesSpawn.hpp
@@ -6,7 +6,7 @@ class Achilles_Spawn_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Spawn_Effects : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SPAWN_EFFECT";
 	function = "Achilles_fnc_SpawnEffect";
 	icon = "\achilles\data_f_achilles\icons\icon_spawnEffects.paa";
@@ -15,7 +15,7 @@ class Achilles_Module_Spawn_Effects : Achilles_Spawn_Module_Base
 
 class Achilles_Module_Spawn_Carrier : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_USS_FREEDOM";
 	function = "Achilles_fnc_SpawnCarrier";
 	icon = "\achilles\data_f_achilles\icons\icon_freedom.paa";
@@ -24,7 +24,7 @@ class Achilles_Module_Spawn_Carrier : Achilles_Spawn_Module_Base
 
 class Achilles_Module_Spawn_Destroyer : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_USS_LIBERTY";
 	function = "Achilles_fnc_SpawnDestroyer";
 	icon = "\achilles\data_f_achilles\icons\icon_liberty.paa";
@@ -33,7 +33,7 @@ class Achilles_Module_Spawn_Destroyer : Achilles_Spawn_Module_Base
 
 class Achilles_Module_Spawn_Explosives : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_MINES_EXPLOSIVES";
 	function = "Achilles_fnc_SpawnExplosives";
 	icon = "\achilles\data_f_achilles\icons\icon_minesAndExplosives.paa";
@@ -42,14 +42,14 @@ class Achilles_Module_Spawn_Explosives : Achilles_Spawn_Module_Base
 
 class Achilles_Module_Spawn_Empty_Object : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SPAWN_EMPTY_OBJECT";
 	function = "Achilles_fnc_SpawnEmptyObject";
 };
 
 class Achilles_Module_Spawn_Advanced_Composition : Achilles_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADVANCED_COMPOSITION";
 	function = "Achilles_fnc_SpawnAdvancedCompositions";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Zeus/cfgVehiclesModulesZeus.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Zeus/cfgVehiclesModulesZeus.hpp
@@ -5,7 +5,7 @@ class Achilles_Zeus_Module_Base : Achilles_Module_Base
 
 class Achilles_Module_Zeus_SwitchUnit : Achilles_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SWITCH_UNIT";
 	function = "Achilles_fnc_ZeusSwitchUnit";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -14,7 +14,7 @@ class Achilles_Module_Zeus_SwitchUnit : Achilles_Zeus_Module_Base
 
 class Achilles_Module_Zeus_AssignZeus : Achilles_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ASSIGN_ZEUS";
 	function = "Achilles_fnc_ZeusAssignZeus";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -22,7 +22,7 @@ class Achilles_Module_Zeus_AssignZeus : Achilles_Zeus_Module_Base
 };
 class ModuleHint_F : Module_F
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	Category = "Curator";
 	displayName = "$STR_AMAE_ADVANCED_HINT";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Behaviours/cfgVehiclesModulesBehaviours.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Behaviours/cfgVehiclesModulesBehaviours.hpp
@@ -9,14 +9,14 @@ class Ares_Behaviours_Module_Base : Ares_Module_Base
 
 class Ares_Module_Bahaviour_SurrenderUnit : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SURRENDER_UNIT";
 	function = "Ares_fnc_BehaviourSurrenderUnits";
 };
 
 class Ares_Module_Bahaviour_Garrison_Nearest : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_GARRISON_INSTANT";
 	function = "Ares_fnc_GarrisonNearest";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -25,7 +25,7 @@ class Ares_Module_Bahaviour_Garrison_Nearest : Ares_Behaviours_Module_Base
 
 class Ares_Module_Bahaviour_UnGarrison : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_UN_GARRISON";
 	function = "Ares_fnc_UnGarrison";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -34,7 +34,7 @@ class Ares_Module_Bahaviour_UnGarrison : Ares_Behaviours_Module_Base
 
 class Ares_Module_Behaviour_Search_Nearby_Building : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SEARCH_BUILDING";
 	function = "Ares_fnc_BehaviourSearchNearbyBuilding";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -43,7 +43,7 @@ class Ares_Module_Behaviour_Search_Nearby_Building : Ares_Behaviours_Module_Base
 
 class Ares_Module_Behaviour_Search_Nearby_And_Garrison : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SEARCH_AND_GARRISON_BUILDING";
 	function = "Ares_fnc_BehaviourSearchNearbyAndGarrison";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";
@@ -52,7 +52,7 @@ class Ares_Module_Behaviour_Search_Nearby_And_Garrison : Ares_Behaviours_Module_
 
 class Ares_Module_Behaviour_Patrol : Ares_Behaviours_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_PATROL_LOITER";
 	function = "Ares_fnc_BehaviourPatrol";
 	icon = "\achilles\data_f_achilles\icons\icon_unit.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Custom/cfgVehiclesModulesUserDefined.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Custom/cfgVehiclesModulesUserDefined.hpp
@@ -6,350 +6,350 @@ class Ares_User_Defined_Module_Base : Ares_Module_Base
 };
 class Ares_Module_User_Defined_0 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 0";
 	function = "Ares_fnc_UserDefinedModule0";
 };
 
 class Ares_Module_User_Defined_1 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 1";
 	function = "Ares_fnc_UserDefinedModule1";
 };
 
 class Ares_Module_User_Defined_2 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 2";
 	function = "Ares_fnc_UserDefinedModule2";
 };
 
 class Ares_Module_User_Defined_3 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 3";
 	function = "Ares_fnc_UserDefinedModule3";
 };
 
 class Ares_Module_User_Defined_4 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 4";
 	function = "Ares_fnc_UserDefinedModule4";
 };
 
 class Ares_Module_User_Defined_5 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 5";
 	function = "Ares_fnc_UserDefinedModule5";
 };
 
 class Ares_Module_User_Defined_6 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 6";
 	function = "Ares_fnc_UserDefinedModule6";
 };
 
 class Ares_Module_User_Defined_7 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 7";
 	function = "Ares_fnc_UserDefinedModule7";
 };
 
 class Ares_Module_User_Defined_8 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 8";
 	function = "Ares_fnc_UserDefinedModule8";
 };
 
 class Ares_Module_User_Defined_9 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 9";
 	function = "Ares_fnc_UserDefinedModule9";
 };
 
 class Ares_Module_User_Defined_10 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 10";
 	function = "Ares_fnc_UserDefinedModule10";
 };
 
 class Ares_Module_User_Defined_11 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 11";
 	function = "Ares_fnc_UserDefinedModule11";
 };
 
 class Ares_Module_User_Defined_12 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 12";
 	function = "Ares_fnc_UserDefinedModule12";
 };
 
 class Ares_Module_User_Defined_13 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 13";
 	function = "Ares_fnc_UserDefinedModule13";
 };
 
 class Ares_Module_User_Defined_14 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 14";
 	function = "Ares_fnc_UserDefinedModule14";
 };
 
 class Ares_Module_User_Defined_15 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 15";
 	function = "Ares_fnc_UserDefinedModule15";
 };
 
 class Ares_Module_User_Defined_16 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 16";
 	function = "Ares_fnc_UserDefinedModule16";
 };
 
 class Ares_Module_User_Defined_17 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 17";
 	function = "Ares_fnc_UserDefinedModule17";
 };
 
 class Ares_Module_User_Defined_18 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 18";
 	function = "Ares_fnc_UserDefinedModule18";
 };
 
 class Ares_Module_User_Defined_19 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 19";
 	function = "Ares_fnc_UserDefinedModule19";
 };
 
 class Ares_Module_User_Defined_20 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 20";
 	function = "Ares_fnc_UserDefinedModule20";
 };
 
 class Ares_Module_User_Defined_21 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 21";
 	function = "Ares_fnc_UserDefinedModule21";
 };
 
 class Ares_Module_User_Defined_22 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 22";
 	function = "Ares_fnc_UserDefinedModule22";
 };
 
 class Ares_Module_User_Defined_23 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 23";
 	function = "Ares_fnc_UserDefinedModule23";
 };
 
 class Ares_Module_User_Defined_24 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 24";
 	function = "Ares_fnc_UserDefinedModule24";
 };
 
 class Ares_Module_User_Defined_25 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 25";
 	function = "Ares_fnc_UserDefinedModule25";
 };
 
 class Ares_Module_User_Defined_26 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 26";
 	function = "Ares_fnc_UserDefinedModule26";
 };
 
 class Ares_Module_User_Defined_27 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 27";
 	function = "Ares_fnc_UserDefinedModule27";
 };
 
 class Ares_Module_User_Defined_28 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 28";
 	function = "Ares_fnc_UserDefinedModule28";
 };
 
 class Ares_Module_User_Defined_29 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 29";
 	function = "Ares_fnc_UserDefinedModule29";
 };
 
 class Ares_Module_User_Defined_30 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 30";
 	function = "Ares_fnc_UserDefinedModule30";
 };
 
 class Ares_Module_User_Defined_31 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 31";
 	function = "Ares_fnc_UserDefinedModule31";
 };
 
 class Ares_Module_User_Defined_32 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 32";
 	function = "Ares_fnc_UserDefinedModule32";
 };
 
 class Ares_Module_User_Defined_33 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 33";
 	function = "Ares_fnc_UserDefinedModule33";
 };
 
 class Ares_Module_User_Defined_34 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 34";
 	function = "Ares_fnc_UserDefinedModule34";
 };
 
 class Ares_Module_User_Defined_35 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 35";
 	function = "Ares_fnc_UserDefinedModule35";
 };
 
 class Ares_Module_User_Defined_36 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 36";
 	function = "Ares_fnc_UserDefinedModule36";
 };
 
 class Ares_Module_User_Defined_37 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 37";
 	function = "Ares_fnc_UserDefinedModule37";
 };
 
 class Ares_Module_User_Defined_38 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 38";
 	function = "Ares_fnc_UserDefinedModule38";
 };
 
 class Ares_Module_User_Defined_39 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 39";
 	function = "Ares_fnc_UserDefinedModule39";
 };
 
 class Ares_Module_User_Defined_40 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 40";
 	function = "Ares_fnc_UserDefinedModule40";
 };
 
 class Ares_Module_User_Defined_41 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 41";
 	function = "Ares_fnc_UserDefinedModule41";
 };
 
 class Ares_Module_User_Defined_42 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 42";
 	function = "Ares_fnc_UserDefinedModule42";
 };
 
 class Ares_Module_User_Defined_43 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 43";
 	function = "Ares_fnc_UserDefinedModule43";
 };
 
 class Ares_Module_User_Defined_44 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 44";
 	function = "Ares_fnc_UserDefinedModule44";
 };
 
 class Ares_Module_User_Defined_45 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 45";
 	function = "Ares_fnc_UserDefinedModule45";
 };
 
 class Ares_Module_User_Defined_46 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 46";
 	function = "Ares_fnc_UserDefinedModule46";
 };
 
 class Ares_Module_User_Defined_47 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 47";
 	function = "Ares_fnc_UserDefinedModule47";
 };
 
 class Ares_Module_User_Defined_48 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 48";
 	function = "Ares_fnc_UserDefinedModule48";
 };
 
 class Ares_Module_User_Defined_49 : Ares_User_Defined_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "User Defined Module 49";
 	function = "Ares_fnc_UserDefinedModule49";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_ares/DevTools/cfgVehiclesModulesDevTools.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/DevTools/cfgVehiclesModulesDevTools.hpp
@@ -6,7 +6,7 @@ class Ares_Dev_Tools_Module_Base : Ares_Module_Base
 
 class Ares_Module_Dev_Tools_Execute_Code : Ares_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_EXECUTE_CODE";
 	function = "Ares_fnc_ExecuteCode";
 	icon = "\achilles\data_f_achilles\icons\icon_default_object.paa";
@@ -14,7 +14,7 @@ class Ares_Module_Dev_Tools_Execute_Code : Ares_Dev_Tools_Module_Base
 };
 class Ares_Module_Dev_Tools_Create_Mission_SQF : Ares_Dev_Tools_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_COPY_MISSION_SQF";
 	function = "Ares_fnc_CreateMissionSQF";
 	icon = "\achilles\data_f_achilles\icons\icon_position.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Equipment/cfgVehiclesModulesEquipment.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Equipment/cfgVehiclesModulesEquipment.hpp
@@ -8,21 +8,21 @@ class Ares_Equipment_Module_Base : Ares_Module_Base
 
 class Ares_Module_Equipment_Turret_Optics : Ares_Equipment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADD_REMOVE_TURRET_OPTICS";
 	function = "Ares_fnc_EquipmentTurretOptics";
 };
 
 class Ares_Module_Equipment_Flashlight_IR_ON_OFF : Ares_Equipment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_TOGGLE_TACLIGHT_IR";
 	function = "Ares_fnc_EquipmentFlashlightIRLaserOnOff";
 };
 
 class Ares_Module_Equipment_NVD_TACLIGHT_IR : Ares_Equipment_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADD_NVD_TACLIGHT_IR";
 	function = "Ares_fnc_EquipmentNVDRailAttachment";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_ares/FireSupport/cfgVehiclesModulesFireSupport.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/FireSupport/cfgVehiclesModulesFireSupport.hpp
@@ -6,7 +6,7 @@ class Ares_Fire_Support_Module_Base : Ares_Module_Base
 
 class Ares_Artillery_Fire_Mission_Module : Ares_Fire_Support_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	_generalMacro = "Ares_Artillery_Fire_Mission_Module";
 	displayName = "$STR_AMAE_ARTILLERY_FIRE_MISSION";
 	function = "Ares_fnc_FireSupportArtilleryFireMission";

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Player/cfgVehiclesModulesPlayer.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Player/cfgVehiclesModulesPlayer.hpp
@@ -9,7 +9,7 @@ class Ares_Player_Module_Base : Ares_Module_Base
 
 class Ares_Module_Player_Teleport : Ares_Player_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_TELEPORT";
 	function = "Ares_fnc_PlayerTeleport";
 	icon = "\achilles\data_f_achilles\icons\icon_position.paa";
@@ -17,7 +17,7 @@ class Ares_Module_Player_Teleport : Ares_Player_Module_Base
 };
 class Ares_Module_Player_Create_Teleporter : Ares_Player_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CREATE_TP";
 	function = "Ares_fnc_PlayerCreateTeleporter";
 	icon = "\achilles\data_f_achilles\icons\icon_position.paa";
@@ -25,7 +25,7 @@ class Ares_Module_Player_Create_Teleporter : Ares_Player_Module_Base
 };
 class Ares_Module_Player_Change_Player_Side : Ares_Player_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CHANGE_SIDE_OF_PLAYER";
 	function = "Ares_fnc_PlayerChangeSide";
 	icon = "\achilles\data_f_achilles\icons\icon_default_unit.paa";
@@ -33,11 +33,11 @@ class Ares_Module_Player_Change_Player_Side : Ares_Player_Module_Base
 };
 class ModuleBootcampStage_F : Module_F 
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	Category = "Achilles_fac_Player";
 };
 class ModulePunishment_F : ModuleBootcampStage_F
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	Category = "Achilles_fac_Player";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Reinforcements/cfgVehiclesModulesReinforcements.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Reinforcements/cfgVehiclesModulesReinforcements.hpp
@@ -6,7 +6,7 @@ class Ares_Reinforcements_Module_base : Ares_Module_Base
 
 class Ares_Module_Reinforcements_Create_Lz : Ares_Reinforcements_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CREATE_NEW_LZ";
 	function = "Ares_fnc_ReinforcementsCreateLz";
 	icon = "\achilles\data_f_ares\icons\icon_lz.paa";
@@ -15,7 +15,7 @@ class Ares_Module_Reinforcements_Create_Lz : Ares_Reinforcements_Module_Base
 
 class Ares_Module_Reinforcements_Create_Rp : Ares_Reinforcements_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_CREATE_NEW_RP";
 	function = "Ares_fnc_ReinforcementsCreateRp";
 	icon = "\achilles\data_f_ares\icons\icon_rp.paa";
@@ -24,7 +24,7 @@ class Ares_Module_Reinforcements_Create_Rp : Ares_Reinforcements_Module_Base
 
 class Ares_Module_Reinforcements_Spawn_Units : Ares_Reinforcements_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SPAWN_UNITS";
 	function = "Ares_fnc_ReinforcementsCreateUnits";
 };

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Spawn/cfgVehiclesModulesSpawn.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Spawn/cfgVehiclesModulesSpawn.hpp
@@ -6,7 +6,7 @@ class Ares_Spawn_Module_Base : Ares_Module_Base
 	
 class Ares_Module_Spawn_Submarine : Ares_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SUBMARINE";
 	function = "Ares_fnc_SpawnSubmarine";
 	icon = "\achilles\data_f_achilles\icons\icon_submarine.paa";
@@ -15,7 +15,7 @@ class Ares_Module_Spawn_Submarine : Ares_Spawn_Module_Base
 
 class Ares_Module_Spawn_Trawler : Ares_Spawn_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_TRAWLER";
 	function = "Ares_fnc_SpawnTrawler";
 	icon = "\achilles\data_f_achilles\icons\icon_trawler.paa";

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/cfgVehiclesModulesZeus.hpp
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/cfgVehiclesModulesZeus.hpp
@@ -6,7 +6,7 @@ class Ares_Zeus_Module_Base : Ares_Module_Base
 
 class Ares_Module_Zeus_Add_Remove_Editable_Objects : Ares_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_ADD_REMOVE_EDITABLE_OBJECTS";
 	function = "Ares_fnc_ZeusAddRemoveEditableObjects";
 	icon = "\achilles\data_f_achilles\icons\icon_position.paa";
@@ -15,7 +15,7 @@ class Ares_Module_Zeus_Add_Remove_Editable_Objects : Ares_Zeus_Module_Base
 
 class Ares_Module_Zeus_Visibility : Ares_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_HIDE_ZEUS";
 	function = "Ares_fnc_ZeusVisibility";
 	icon = "\achilles\data_f_achilles\icons\icon_hideZeus.paa";
@@ -24,7 +24,7 @@ class Ares_Module_Zeus_Visibility : Ares_Zeus_Module_Base
 
 class Ares_Module_Zeus_Hint : Ares_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_HINT";
 	function = "Ares_fnc_ZeusHint";
 	icon = "\achilles\data_f_achilles\icons\icon_hint.paa";
@@ -33,7 +33,7 @@ class Ares_Module_Zeus_Hint : Ares_Zeus_Module_Base
 
 class Ares_Module_Zeus_Switch_Side : Ares_Zeus_Module_Base
 {
-	scopeCurator = 2;
+	scopeCurator = 1;
 	displayName = "$STR_AMAE_SWITCH_SIDE_CHANNEL_OF_ZEUS";
 	function = "Ares_fnc_ZeusSwitchSideChannel";
 	icon = "\achilles\data_f_ares\icons\icon_default.paa";

--- a/@AresModAchillesExpansion/addons/settings_f/config.cpp
+++ b/@AresModAchillesExpansion/addons/settings_f/config.cpp
@@ -26,10 +26,6 @@ class Extended_PreInit_EventHandlers
     {
         init = "call compile preProcessFileLineNumbers '\achilles\settings_f\scripts\XEH_preInit.sqf'";
     };
-	class achilles_fnc_missionIsloadedFromSafeEH
-	{
-		init = "addMissionEventHandler ['Loaded', {missionNamespace setVariable ['Achilles_var_missionIsLoadedFromSafe', true]}]";
-	};
 };
 
 #include "cfgFunctions.hpp"

--- a/@AresModAchillesExpansion/addons/settings_f/config.cpp
+++ b/@AresModAchillesExpansion/addons/settings_f/config.cpp
@@ -26,6 +26,10 @@ class Extended_PreInit_EventHandlers
     {
         init = "call compile preProcessFileLineNumbers '\achilles\settings_f\scripts\XEH_preInit.sqf'";
     };
+	class achilles_fnc_missionIsloadedFromSafeEH
+	{
+		init = "addMissionEventHandler ['Loaded', {missionNamespace setVariable ['Achilles_var_missionIsLoadedFromSafe', true]}]";
+	};
 };
 
 #include "cfgFunctions.hpp"

--- a/@AresModAchillesExpansion/addons/settings_f/scripts/XEH_preInit.sqf
+++ b/@AresModAchillesExpansion/addons/settings_f/scripts/XEH_preInit.sqf
@@ -13,6 +13,7 @@
 #include "module_tree.sqf"
 #include "curator_vision.sqf"
 #include "available_factions.sqf"
+#include "available_modules.sqf"
 #include "icon_selection.sqf"
 #include "keybindings.sqf"
 #include "debugMessages.sqf"

--- a/@AresModAchillesExpansion/addons/settings_f/scripts/available_factions.sqf
+++ b/@AresModAchillesExpansion/addons/settings_f/scripts/available_factions.sqf
@@ -40,7 +40,7 @@ _factions =
 					Achilles_var_excludedFactions = Achilles_var_excludedFactions - [""" + _factionName + """]
 				} else
 				{
-					Achilles_var_excludedFactions pushBack """ + _factionName + """;
+					Achilles_var_excludedFactions pushBackUnique """ + _factionName + """;
 				};
 				Achilles_var_reloadDisplay = true;
 				uiNamespace setVariable [""Achilles_var_nestedList_vehicleFactions"", []];

--- a/@AresModAchillesExpansion/addons/settings_f/scripts/available_factions.sqf
+++ b/@AresModAchillesExpansion/addons/settings_f/scripts/available_factions.sqf
@@ -3,39 +3,49 @@
 Achilles_var_excludedFactions = [];
 
 private _factions = ([configfile >> "CfgFactionClasses"] call BIS_fnc_getCfgSubClasses);
-private _factionNames = [];
+_factions =
+[
+	_factions,
+	[],
+	{
+		private _faction = _x;
+		private _factionCfg = (configfile >> "CfgFactionClasses" >> _faction);
+		private _factionName = getText (_factionCfg >> "displayName");
+		private _sideId = [_factionCfg, "side", -1] call BIS_fnc_returnConfigEntry;
+		private _sideName = [_sideId] call BIS_fnc_sideName;
+		format ["%1%2", _sideName, _factionName]
+	}
+] call BIS_fnc_sortBy;
 
 {
 	private _faction = _x;
-	private _factionCfgPath = (configfile >> "CfgFactionClasses" >> _faction);
-	if (([_factionCfgPath, "side", -1] call BIS_fnc_returnConfigEntry) in [0,1,2,3]) then
+	private _factionCfg = (configfile >> "CfgFactionClasses" >> _faction);
+	private _sideId = [_factionCfg, "side", -1] call BIS_fnc_returnConfigEntry;
+	if (_sideId in [0,1,2,3]) then
 	{
-		private _factionName = [_factionCfgPath, "displayName", ""] call BIS_fnc_returnConfigEntry;
-		if (not (_factionName in _factionNames)) then
-		{
-			_factionNames pushBack _factionName;
-			[
-				format ["Achilles_var_%1",_faction],
-				"CHECKBOX",
-				_factionName,
-				localize "STR_AMAE_AVAILABLE_FACTIONS",
-				true,
-				false,
-				compile 
-				("
-					params [""_value""]; 
-					if (_value) then 
-					{
-						Achilles_var_excludedFactions = Achilles_var_excludedFactions - [""" + _factionName + """]
-					} else
-					{
-						Achilles_var_excludedFactions pushBack """ + _factionName + """;
-					};
-					Achilles_var_reloadDisplay = true;
-					uiNamespace setVariable [""Achilles_var_nestedList_vehicleFactions"", []];
-					uiNamespace setVariable [""Achilles_var_supplyDrop_factions"", []];
-				")
-			] call cba_settings_fnc_init;
-		};
+		private _factionName = getText (_factionCfg >> "displayName");
+		private _sideName = [_sideId] call BIS_fnc_sideName;
+		[
+			format ["Achilles_var_%1", _faction],
+			"CHECKBOX",
+			format ["%1: %2", _sideName, _factionName],
+			localize "STR_AMAE_AVAILABLE_FACTIONS",
+			true,
+			false,
+			compile 
+			("
+				params [""_value""]; 
+				if (_value) then 
+				{
+					Achilles_var_excludedFactions = Achilles_var_excludedFactions - [""" + _factionName + """]
+				} else
+				{
+					Achilles_var_excludedFactions pushBack """ + _factionName + """;
+				};
+				Achilles_var_reloadDisplay = true;
+				uiNamespace setVariable [""Achilles_var_nestedList_vehicleFactions"", []];
+				uiNamespace setVariable [""Achilles_var_supplyDrop_factions"", []];
+			")
+		] call cba_settings_fnc_init;
 	};
 } forEach _factions;

--- a/@AresModAchillesExpansion/addons/settings_f/scripts/available_modules.sqf
+++ b/@AresModAchillesExpansion/addons/settings_f/scripts/available_modules.sqf
@@ -34,7 +34,7 @@ _achillesModuleClasses =
 			params [""_value""]; 
 			if (_value) then 
 			{
-				Achilles_var_availableModuleClasses pushBack """ + _moduleClass + """;
+				Achilles_var_availableModuleClasses pushBackUnique """ + _moduleClass + """;
 			} else
 			{
 				Achilles_var_availableModuleClasses = Achilles_var_availableModuleClasses - [""" + _moduleClass + """];

--- a/@AresModAchillesExpansion/addons/settings_f/scripts/available_modules.sqf
+++ b/@AresModAchillesExpansion/addons/settings_f/scripts/available_modules.sqf
@@ -1,0 +1,45 @@
+Achilles_var_availableModuleClasses = [];
+
+private _achillesModuleClasses = (getArray (configFile >> "cfgPatches" >> "achilles_modules_f_ares" >> "units"));
+_achillesModuleClasses append (getArray (configFile >> "cfgPatches" >> "achilles_modules_f_achilles" >> "units"));
+_achillesModuleClasses =
+[
+	_achillesModuleClasses,
+	[], 
+	{
+		private _moduleClass = _x;
+		private _moduleCfg = configFile >> "cfgVehicles" >> _moduleClass;
+		private _moduleName = getText (_moduleCfg >> "displayName");
+		private _categoryClass = getText (_moduleCfg >> "category");
+		private _categoryName = getText (configFile >> "CfgFactionClasses" >> _categoryClass >> "displayName");
+		format ["%1%2", _categoryName, _moduleName]
+	}
+] call BIS_fnc_sortBy;
+
+{
+	private _moduleClass = _x;
+	private _moduleCfg = configFile >> "cfgVehicles" >> _moduleClass;
+	private _moduleName = getText (_moduleCfg >> "displayName");
+	private _categoryClass = getText (_moduleCfg >> "category");
+	private _categoryName = getText (configFile >> "CfgFactionClasses" >> _categoryClass >> "displayName");
+	[
+		format ["Achilles_var_%1", _moduleClass],
+		"CHECKBOX",
+		format ["%1: %2", _categoryName, _moduleName],
+		localize "STR_AMAE_AVAILABLE_MODULES",
+		true,
+		false,
+		compile 
+		("
+			params [""_value""]; 
+			if (_value) then 
+			{
+				Achilles_var_availableModuleClasses pushBack """ + _moduleClass + """;
+			} else
+			{
+				Achilles_var_availableModuleClasses = Achilles_var_availableModuleClasses - [""" + _moduleClass + """];
+			};
+			Achilles_var_reloadDisplay = true;
+		")
+	] call cba_settings_fnc_init;
+} forEach _achillesModuleClasses;

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
@@ -19,12 +19,24 @@
 //	_this				ARRAY	- updated list of all category display names
 //
 //	Example:
-//	_category_list = [_ctrl,_category_list,_categoryName,_moduleDisplayName,_moduleClassName,_forEachIndex,_moduleIcon,_addonIcon] call Achilles_fnc_AppendToModuleTree;
+//	_categoryList = [_ctrl,_categoryList,_categoryName,_moduleDisplayName,_moduleClassName,_forEachIndex,_moduleIcon,_addonIcon] call Achilles_fnc_AppendToModuleTree;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-params ["_ctrl", "_category_list", "_categoryName", "_moduleDisplayName", "_moduleClassName", ["_value", 0, [0]], ["_moduleIcon", "\achilles\data_f_ares\icons\icon_default.paa", [""]], ["_addonIcon", "\achilles\data_f_achilles\icons\icon_achilles_small.paa", [""]]];
+#define CATEGORY_ICON	"\achilles\data_f_achilles\icons\icon_achilles_small.paa"
 
-private _categoryIndex = _category_list find _categoryName;
+params
+[
+	"_ctrl",
+	"_categoryList",
+	"_categoryName",
+	"_moduleDisplayName",
+	"_moduleClassName",
+	["_value", 0, [0]],
+	["_moduleIcon", "\achilles\data_f_ares\icons\icon_default.paa", [""]],
+	["_addonIcon", "\achilles\data_f_achilles\icons\icon_achilles_small.paa", [""]]
+];
+
+private _categoryIndex = _categoryList find _categoryName;
 
 if (_categoryIndex == -1) then
 {
@@ -35,10 +47,10 @@ if (_categoryIndex == -1) then
 	_ctrl tvSetData [[_tvBranch], _tvData];
 	if (Achilles_var_moduleTreeHelmet) then
 	{
-		_ctrl tvSetPicture [[_tvBranch], _addonIcon];
+		_ctrl tvSetPicture [[_tvBranch], CATEGORY_ICON];
 	};
-	_categoryIndex = count _category_list;
-	_category_list pushBack _categoryName;
+	_categoryIndex = count _categoryList;
+	_categoryList pushBack _categoryName;
 };
 
 private _moduleIndex = _ctrl tvAdd [[_categoryIndex], _moduleDisplayName];
@@ -52,4 +64,4 @@ if (Achilles_var_moduleTreeDLC) then
     _ctrl tvSetPictureRight [_newPath, _addonIcon];
 };
 
-_category_list
+_categoryList

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
@@ -55,7 +55,6 @@ if (_categoryIndex == -1) then
 
 private _moduleIndex = _ctrl tvAdd [[_categoryIndex], _moduleDisplayName];
 private _newPath = [_categoryIndex, _moduleIndex];
-systemChat str [_categoryName, _categoryIndex, _moduleDisplayName, _moduleIndex];
 _ctrl tvSetData [_newPath, _moduleClassName];
 _ctrl tvSetPicture [_newPath, _moduleIcon];
 _ctrl tvSetValue [_newPath, _value];

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_AppendToModuleTree.sqf
@@ -55,6 +55,7 @@ if (_categoryIndex == -1) then
 
 private _moduleIndex = _ctrl tvAdd [[_categoryIndex], _moduleDisplayName];
 private _newPath = [_categoryIndex, _moduleIndex];
+systemChat str [_categoryName, _categoryIndex, _moduleDisplayName, _moduleIndex];
 _ctrl tvSetData [_newPath, _moduleClassName];
 _ctrl tvSetPicture [_newPath, _moduleIcon];
 _ctrl tvSetValue [_newPath, _value];

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onDisplayCuratorLoad.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onDisplayCuratorLoad.sqf
@@ -20,7 +20,7 @@
 #define IDC_TEXT_WARNING		235102
 #define IDC_CONFIRM_WARNING		235106
 #define IDC_CANCLE_WARNING		235107
-#define ALL_ADD_CREATE_IDCS	[IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EAST, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_WEST, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_GUER, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_CIV, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_EAST, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_WEST, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_GUER, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_CIV, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_EMPTY]
+#define ALL_ADD_CREATE_IDCS		[IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EAST, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_WEST, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_GUER, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_CIV, IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_EAST, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_WEST, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_GUER, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_CIV, IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_EMPTY]
 #define ALL_ADD_MODE_IDCS		[IDC_RSCDISPLAYCURATOR_MODEUNITS, IDC_RSCDISPLAYCURATOR_MODEGROUPS, IDC_RSCDISPLAYCURATOR_MODEMODULES, IDC_RSCDISPLAYCURATOR_MODEMARKERS, IDC_RSCDISPLAYCURATOR_MODERECENT]
 #define ALL_ADD_SIDE_IDCS		[IDC_RSCDISPLAYCURATOR_SIDEOPFOR, IDC_RSCDISPLAYCURATOR_SIDEBLUFOR, IDC_RSCDISPLAYCURATOR_SIDEINDEPENDENT, IDC_RSCDISPLAYCURATOR_SIDECIVILIAN, IDC_RSCDISPLAYCURATOR_SIDEEMPTY]
 
@@ -30,135 +30,136 @@
 // custom stacked curator display event handler
 ["Achilles_onLoadCuratorInterface", _this, player] call CBA_fnc_targetEvent;
 
-_this spawn
+params ["_display"];
+private _moduleTreeCtrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
+
+if (isNil "Achilles_curator_init_done") then
 {
-	disableSerialization;
-	private _display_reload = false;
-	private _display = _this select 0;
-	private _tree_ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
-		
-	if (isNil "Achilles_curator_init_done") then
-	{
-		// key event handler for remote controlled unit
-		private _main_display = findDisplay 46;
-		_main_display displayAddEventHandler ["KeyDown", { _this call Achilles_fnc_HandleRemoteKeyPressed; }];
-		
-		// send warning to player if both mods are running
-		if (isClass (configfile >> "CfgPatches" >> "Ares")) then 
-		{
-			createDialog "RscDisplayCommonMessage";
-			private _dialog = findDisplay IDD_MESSAGE;
-			(_dialog displayCtrl IDC_TITLE) ctrlSetText "Warning: Please unload Ares Mod!";
-			(_dialog displayCtrl IDC_TEXT_WARNING) ctrlSetText "Achilles may not work properly!";
-			(_dialog displayCtrl IDC_CONFIRM_WARNING) ctrlAddEventHandler ["ButtonClick","closeDialog 1;"];
-			(_dialog displayCtrl IDC_CANCLE_WARNING) ctrlAddEventHandler ["ButtonClick", "closeDialog 2;"];
-		};
-		
-		// execute init
-		_display_reload = [_tree_ctrl] call Achilles_fnc_onCuratorStart;
-		
-		Achilles_curator_init_done = true;
-		
-		// display advanced hints
-		private _hasHintBeenShown = profileNamespace getVariable ["Achilles_var_advHint_showIntro", false];
-		if (!_hasHintBeenShown) then
-		{
-			[["Ares", "AresFieldManual"],15,"",35,"",true] call BIS_fnc_advHint;
-			profileNamespace setVariable ["Achilles_var_advHint_showIntro", true];
-		};
-	};
-	// prevent unessecary double execution of functions below
-	if (_display_reload) exitWith {};
+	// key event handler for remote controlled unit
+	private _mainDisplay = findDisplay 46;
+	_mainDisplay displayAddEventHandler ["KeyDown", { _this call Achilles_fnc_handleRemoteKeyPressed; }];
 	
-	//wait unit Remote Control is truly terminated (fix connection issues with TFAR)
-	if (isClass (configfile >> "CfgPatches" >> "task_force_radio")) then
+	// send warning to player if both mods are running
+	if (isClass (configfile >> "CfgPatches" >> "Ares")) then 
 	{
-		waitUntil {sleep 1; (missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player]) == player};
+		createDialog "RscDisplayCommonMessage";
+		private _dialog = findDisplay IDD_MESSAGE;
+		(_dialog displayCtrl IDC_TITLE) ctrlSetText "Warning: Please unload Ares Mod!";
+		(_dialog displayCtrl IDC_TEXT_WARNING) ctrlSetText "Achilles may not work properly!";
+		(_dialog displayCtrl IDC_CONFIRM_WARNING) ctrlAddEventHandler ["ButtonClick","closeDialog 1;"];
+		(_dialog displayCtrl IDC_CANCLE_WARNING) ctrlAddEventHandler ["ButtonClick", "closeDialog 2;"];
 	};
 	
-	_display displayAddEventHandler ["KeyDown",{_this call Achilles_fnc_HandleCuratorKeyPressed;}];
-	(_display displayCtrl IDC_RSCDISPLAYCURATOR_MOUSEAREA) ctrlAddEventHandler ["MouseButtonDblClick",{_this call Achilles_fnc_HandleMouseDoubleClicked;}];
-	(_display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP) ctrlAddEventHandler ["MouseButtonDblClick",{_this call Achilles_fnc_HandleMouseDoubleClicked;}];
+	// execute init
+	[_moduleTreeCtrl] call Achilles_fnc_onCuratorStart;
 	
-	// Fixes the loss of sides in the module tree caused by an ongoing search
+	// display advanced hints
+	private _hasHintBeenShown = profileNamespace getVariable ["Achilles_var_advHint_showIntro", false];
+	if (!_hasHintBeenShown) then
 	{
-		private _ctrl = _display displayCtrl _x;
-		_ctrl ctrlAddEventHandler ["ButtonClick",
+		[["Ares", "AresFieldManual"],15,"",35,"",true] call BIS_fnc_advHint;
+		profileNamespace setVariable ["Achilles_var_advHint_showIntro", true];
+	};
+	
+	Achilles_curator_init_done = true;
+};
+
+// Add mouse click event handlers
+_display displayAddEventHandler ["KeyDown",{_this call Achilles_fnc_handleCuratorKeyPressed;}];
+(_display displayCtrl IDC_RSCDISPLAYCURATOR_MOUSEAREA) ctrlAddEventHandler ["MouseButtonDblClick",{_this call Achilles_fnc_handleMouseDoubleClicked;}];
+(_display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP) ctrlAddEventHandler ["MouseButtonDblClick",{_this call Achilles_fnc_handleMouseDoubleClicked;}];
+
+// Fixes the loss of sides in the module tree caused by an ongoing search
+{
+	private _ctrl = _display displayCtrl _x;
+	_ctrl ctrlAddEventHandler ["ButtonClick",
+	{
+		params ["_ctrlMode"];
+		private _display = ctrlParent _ctrlMode;
+		private	_ctrlSearch = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_SEARCH;
+		private _searchText = ctrlText _ctrlSearch;
+		(missionNamespace getVariable ["RscDisplayCurator_sections", [0,0]]) params ["_","_curSide"];
+		private _curMode = ALL_ADD_MODE_IDCS find ctrlIDC _ctrlMode;
+		if (_searchText != "") then
 		{
-			params ["_ctrlMode"];
-			private _display = ctrlParent _ctrlMode;
-			private	_ctrlSearch = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_SEARCH;
-			private _searchText = ctrlText _ctrlSearch;
-			(missionNamespace getVariable ["RscDisplayCurator_sections", [0,0]]) params ["_","_curSide"];
-			private _curMode = ALL_ADD_MODE_IDCS find ctrlIDC _ctrlMode;
-			if (_searchText != "") then
+			private _ctrlCreateList = ALL_ADD_CREATE_IDCS apply {_display displayCtrl _x};
+			if (_curMode <= 1) then
 			{
-				private _ctrlCreateList = ALL_ADD_CREATE_IDCS apply {_display displayCtrl _x};
-				if (_curMode <= 1) then
-				{
-					_ctrlCreateList deleteAt (5 * _curMode + _curSide);
-				};
-				[_ctrlCreateList,_ctrlSearch,_searchText] spawn
-				{
-					disableSerialization;
-					params ["_ctrlCreateList","_ctrlSearch","_searchText"];
-					{_x ctrlSetFade 0.99; _x ctrlShow true; _x ctrlCommit 0} forEach _ctrlCreateList;
-					waitUntil {{not ctrlShown _x} count _ctrlCreateList == 0};
-					_ctrlSearch ctrlSetText "";
-					uiSleep 0.05;
-					{_x ctrlShow false; _x ctrlSetFade 0; _x ctrlCommit 0} forEach _ctrlCreateList;
-					waitUntil {{ctrlShown _x} count _ctrlCreateList == 0};
-					_ctrlSearch ctrlSetText _searchText;
-				};
+				_ctrlCreateList deleteAt (5 * _curMode + _curSide);
 			};
-		}];
-	} forEach ALL_ADD_MODE_IDCS;
-	{
-		private _ctrl = _display displayCtrl _x;
-		_ctrl ctrlAddEventHandler ["ButtonClick",
-		{
-			params ["_ctrlSide"];
-			private _display = ctrlParent _ctrlSide;
-			private	_ctrlSearch = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_SEARCH;
-			private _searchText = ctrlText _ctrlSearch;
-			(missionNamespace getVariable ["RscDisplayCurator_sections", [0,0]]) params ["_curMode"];
-			private _curSide = ALL_ADD_SIDE_IDCS find ctrlIDC _ctrlSide;
-			if (_searchText != "") then
+			[_ctrlCreateList,_ctrlSearch,_searchText] spawn
 			{
-				private _ctrlCreateList = ALL_ADD_CREATE_IDCS apply {_display displayCtrl _x};
-				if (_curMode <= 1) then
-				{
-					_ctrlCreateList deleteAt (5 * _curMode + _curSide);
-				};
-				[_ctrlCreateList,_ctrlSearch,_searchText] spawn
-				{
-					disableSerialization;
-					params ["_ctrlCreateList","_ctrlSearch","_searchText"];
-					{_x ctrlSetFade 0.99; _x ctrlShow true; _x ctrlCommit 0} forEach _ctrlCreateList;
-					waitUntil {{not ctrlShown _x} count _ctrlCreateList == 0};
-					_ctrlSearch ctrlSetText "";
-					uiSleep 0.05;
-					{_x ctrlShow false; _x ctrlSetFade 0; _x ctrlCommit 0} forEach _ctrlCreateList;
-					waitUntil {{ctrlShown _x} count _ctrlCreateList == 0};
-					_ctrlSearch ctrlSetText _searchText;
-				};
+				disableSerialization;
+				params ["_ctrlCreateList","_ctrlSearch","_searchText"];
+				{_x ctrlSetFade 0.99; _x ctrlShow true; _x ctrlCommit 0} forEach _ctrlCreateList;
+				waitUntil {{not ctrlShown _x} count _ctrlCreateList == 0};
+				_ctrlSearch ctrlSetText "";
+				uiSleep 0.05;
+				{_x ctrlShow false; _x ctrlSetFade 0; _x ctrlCommit 0} forEach _ctrlCreateList;
+				waitUntil {{ctrlShown _x} count _ctrlCreateList == 0};
+				_ctrlSearch ctrlSetText _searchText;
 			};
-		}];
-	} forEach ALL_ADD_SIDE_IDCS;
-	
-	// Add custom Zeus logo when pressing backspace
-	private _zeusLogo = (findDisplay 312) displayCtrl 15717;
-	private _addLogo = true;
-	switch (Achilles_var_iconSelection) do 
+		};
+	}];
+} forEach ALL_ADD_MODE_IDCS;
+{
+	private _ctrl = _display displayCtrl _x;
+	_ctrl ctrlAddEventHandler ["ButtonClick",
 	{
-		case "Achilles_var_iconSelection_Ares": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\ZeusEyeAres.paa"};
-		case "Achilles_var_iconSelection_Achilles": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\Achilles_Icon_005.paa"};
-		case "Achilles_var_iconSelection_Enyo": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\icons\icon_enyo_large.paa"};
-		case "Achilles_var_iconSelection_Default": {_addLogo = false};
-		default {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\ZeusEyeAres.paa"};
+		params ["_ctrlSide"];
+		private _display = ctrlParent _ctrlSide;
+		private	_ctrlSearch = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_SEARCH;
+		private _searchText = ctrlText _ctrlSearch;
+		(missionNamespace getVariable ["RscDisplayCurator_sections", [0,0]]) params ["_curMode"];
+		private _curSide = ALL_ADD_SIDE_IDCS find ctrlIDC _ctrlSide;
+		if (_searchText != "") then
+		{
+			private _ctrlCreateList = ALL_ADD_CREATE_IDCS apply {_display displayCtrl _x};
+			if (_curMode <= 1) then
+			{
+				_ctrlCreateList deleteAt (5 * _curMode + _curSide);
+			};
+			[_ctrlCreateList,_ctrlSearch,_searchText] spawn
+			{
+				disableSerialization;
+				params ["_ctrlCreateList","_ctrlSearch","_searchText"];
+				{_x ctrlSetFade 0.99; _x ctrlShow true; _x ctrlCommit 0} forEach _ctrlCreateList;
+				waitUntil {{not ctrlShown _x} count _ctrlCreateList == 0};
+				_ctrlSearch ctrlSetText "";
+				uiSleep 0.05;
+				{_x ctrlShow false; _x ctrlSetFade 0; _x ctrlCommit 0} forEach _ctrlCreateList;
+				waitUntil {{ctrlShown _x} count _ctrlCreateList == 0};
+				_ctrlSearch ctrlSetText _searchText;
+			};
+		};
+	}];
+} forEach ALL_ADD_SIDE_IDCS;
+
+// Add custom Zeus logo when pressing backspace
+private _zeusLogo = _display displayCtrl 15717;
+private _addLogo = true;
+switch (Achilles_var_iconSelection) do 
+{
+	case "Achilles_var_iconSelection_Ares": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\ZeusEyeAres.paa"};
+	case "Achilles_var_iconSelection_Achilles": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\Achilles_Icon_005.paa"};
+	case "Achilles_var_iconSelection_Enyo": {_zeusLogo ctrlSetText "\achilles\data_f_achilles\icons\icon_enyo_large.paa"};
+	case "Achilles_var_iconSelection_Default": {_addLogo = false};
+	default {_zeusLogo ctrlSetText "\achilles\data_f_achilles\pictures\ZeusEyeAres.paa"};
+};
+if (_addLogo) then {_zeusLogo ctrlCommit 0};
+
+// handle module tree loading
+[_moduleTreeCtrl] spawn
+{
+	params ["_moduleTreeCtrl"];
+	// For Zeus Game Master missions: Wait until respawn was placed
+	if (!(missionNamespace getVariable ["BIS_moduleMPTypeGameMaster_init", false]) && {count allMissionObjects "ModuleMPTypeGameMaster_F" > 0}) then
+	{
+		waitUntil {sleep 0.1; _moduleTreeCtrl tvCount [] > 1 || isNull findDisplay IDD_RSCDISPLAYCURATOR};
 	};
-	if (_addLogo) then {_zeusLogo ctrlCommit 0};
+	if (isNull findDisplay IDD_RSCDISPLAYCURATOR) exitWith {};
 	
-	// handle module tree loading
-	[true] call Achilles_fnc_OnModuleTreeLoad;
+	// wait for the next frame
+	sleep 0.001;
+	[Achilles_fnc_onModuleTreeLoad, []] call CBA_fnc_directCall;
 };

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onModuleTreeLoad.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onModuleTreeLoad.sqf
@@ -12,124 +12,101 @@
 //	nothing (procedure)
 //
 //	Example:
-//	[false] call Achilles_fnc_OnModuleTreeLoad;
+//	[] call Achilles_fnc_onModuleTreeLoad;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "\A3\ui_f_curator\ui\defineResinclDesign.inc"
-#define ACHILLES_CATEGORIES [localize "STR_AMAE_BUILDINGS",localize "STR_AMAE_OBJECTS",localize "STR_AMAE_ARSENAL",localize "STR_AMAE_AI_BEHAVIOUR",localize "STR_AMAE_DEV_TOOLS",localize "STR_AMAE_EQUIPMENT",localize "STR_AMAE_PLAYERS",localize "STR_AMAE_REINFORCEMENTS",localize "STR_AMAE_SPAWN"]
 
 disableSerialization;
 
-// Get function  arguments
-private _custom_only = param [0,false,[false]];
-
 // Get the UI control
 private _display = findDisplay IDD_RSCDISPLAYCURATOR;
-private _ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
+private _moduleTreeCtrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
 
-
-//prepare lists
-private _category_list = [];
-private _all_modules = (getArray (configFile >> "cfgPatches" >> "achilles_modules_f_ares" >> "units"));
-_all_modules append (getArray (configFile >> "cfgPatches" >> "achilles_modules_f_achilles" >> "units"));
-
-// Get all Vanilla Categories
-
-
-for "_i" from 0 to ((_ctrl tvCount []) - 1) do
+// Get all existing module categories
+private _categoryList = [];
+for "_i" from 0 to ((_moduleTreeCtrl tvCount []) - 1) do
 {
-	private _categoryName = _ctrl tvText [_i];
-	if (Achilles_var_moduleTreeHelmet and (_categoryName in ACHILLES_CATEGORIES)) then
-	{
-		_ctrl tvSetPicture [[_i], "\achilles\data_f_achilles\icons\icon_achilles_small.paa"];
-	};
-	_category_list pushBack _categoryName;
+	_categoryList pushBack (_moduleTreeCtrl tvText [_i]);
 };
 
-
-
-// add dlc icons
-for "_i" from 0 to ((_ctrl tvCount []) - 1) do
+if !(missionNamespace getVariable ["Achilles_var_missionIsLoadedFromSafe", false]) then
 {
-	for "_j" from 0 to ((_ctrl tvCount [_i]) - 1) do
+	// Add achilles modules
 	{
-		private _path = [_i,_j];
-		private _moduleClassName = _ctrl tvData _path;
-		if (Achilles_var_moduleTreeDLC) then
+		private _moduleClass = _x;
+		private _moduleCfg = configFile >> "cfgVehicles" >> _moduleClass;
+		private _moduleName = getText (_moduleCfg >> "displayName");
+		private _moduleIcon = getText (_moduleCfg >> "portrait");
+		private _categoryClass = getText (_moduleCfg >> "category");
+		private _categoryName = getText (configFile >> "CfgFactionClasses" >> _categoryClass >> "displayName");
+		private _dlc = getText (_moduleCfg >> "dlc");
+		private _addonIcon = getText (configFile >> "CfgMods" >> _dlc >> "logoSmall");
+		_categoryList =
+		[
+			_moduleTreeCtrl,
+			_categoryList,
+			_categoryName,
+			_moduleName,
+			_moduleClass,
+			0,
+			_moduleIcon,
+			_addonIcon
+		] call Achilles_fnc_appendToModuleTree;
+	} forEach Achilles_var_availableModuleClasses;
+	systemChat str [Achilles_var_availableModuleClasses, "Achilles_var_availableModuleClasses"];
+
+	// Add custom modules
+	if (!isNil "Ares_Custom_Modules") then
+	{
 		{
-			private _dlc = [(configFile >> "CfgVehicles" >> _moduleClassName), "dlc", ""] call BIS_fnc_returnConfigEntry;
-			private _addonIcon = [(configFile >> "CfgMods" >> _dlc), "logoSmall", ""] call BIS_fnc_returnConfigEntry;
-			if (_addonIcon != "") then
-			{
-				_ctrl tvSetPictureRight [_path, _addonIcon];
-			};
-		};
+			_x params
+			[
+				"_categoryName",
+				"_moduleDisplayName"
+			];
+			private _moduleClassName = format ["Ares_Module_User_Defined_%1", _forEachIndex];
+
+			_categoryList =
+			[
+				_moduleTreeCtrl,
+				_categoryList,
+				_categoryName,
+				_moduleDisplayName,
+				_moduleClassName
+			] call Achilles_fnc_appendToModuleTree;
+		} forEach Ares_Custom_Modules;
+	};
+
+	//Sort category and module list
+	_moduleTreeCtrl tvSort [[], false];
+	for "_i" from 0 to ((_moduleTreeCtrl tvCount []) - 1) do
+	{
+		_moduleTreeCtrl tvSort [[_i], false];
 	};
 };
 
-
-// Add Custom modules
-if (!isNil "Ares_Custom_Modules") then
-{
-	{
-		private _categoryName = _x select 0;
-		private _moduleDisplayName = _x select 1;
-		private _moduleClassName = format ["Ares_Module_User_Defined_%1", _forEachIndex];
-
-		_category_list = [_ctrl,_category_list,_categoryName,_moduleDisplayName,_moduleClassName,_forEachIndex] call Achilles_fnc_AppendToModuleTree;
-	} forEach Ares_Custom_Modules;
-};
-
-//Sort category and module list
-_ctrl tvSort [[], false];
-for "_i" from 0 to ((_ctrl tvCount []) - 1) do {_ctrl tvSort [[_i], false];};
-
-//get module list
+// Set module category list for 
 _category_list sort true;
 Ares_category_list = _category_list;
 
-
-/*
-_tree_ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY;
-
-//Add missing objects: Rocks
-
-_categoryName = getText (configfile >> "CfgEditorCategories" >> "EdCat_Environment" >> "displayName");
-_categoryIndex = _tree_ctrl tvAdd [[],_categoryName];
-_subCategoryName = getText (configfile >> "CfgEditorSubcategories" >> "EdSubcat_Rocks" >> "displayName");
-_subCategoryIndex = _tree_ctrl tvAdd [[_categoryIndex],_subCategoryName];
-{
-	_objectName = getText (configfile >> "CfgVehicles" >> _x >> "displayName");
-	_objectIndex =  _tree_ctrl tvAdd [[_categoryIndex,_subCategoryIndex],_objectName];
-	_tree_ctrl tvSetData [[_categoryIndex,_subCategoryIndex,_objectIndex],_x];
-} forEach ((configfile >> "CfgVehicles" >> "Rocks_base_F") call Achilles_fnc_ClassNamesWhichInheritsFromCfgClass);
-_tree_ctrl tvSort [[_categoryIndex,_subCategoryIndex],false];
-_tree_ctrl tvSort [[],false];
-
-//Add missing objects: Ruins
-_categoryName = getText (configfile >> "CfgEditorCategories" >> "EdCat_Environment" >> "displayName");
-_categoryIndex = _tree_ctrl tvAdd [[],_categoryName];
-
-//{} forEach ((configfile >> "CfgVehicles" >> "Ruins_F") call Achilles_fnc_ClassNamesWhichInheritsFromCfgClass);
-*/
-
-//collapse unit tree or remove faction
+// Create unit trees: Filter and collapse
 if (count Achilles_var_excludedFactions > 0 or Achilles_var_moduleTreeCollapse) then
 {
 	{
-		private _tree_ctrl = _display displayCtrl _x;
-		for "_i" from ((_tree_ctrl tvCount []) - 1) to 0 step -1 do
+		private _treeCtrl = _display displayCtrl _x;
+		for "_i" from ((_treeCtrl tvCount []) - 1) to 0 step -1 do
 		{
 			private _path = [_i];
-			private _faction_name = _tree_ctrl tvText _path;
-			if (_faction_name in Achilles_var_excludedFactions) then
+			private _factionName = _treeCtrl tvText _path;
+			if (_factionName in Achilles_var_excludedFactions) then
 			{
-				_tree_ctrl tvDelete _path;
+				_treeCtrl tvDelete _path;
 			} else
 			{
 				if (Achilles_var_moduleTreeCollapse) then
 				{
-					_tree_ctrl tvCollapse _path;
+					_treeCtrl tvCollapse _path;
 				};
 			};
 		};
@@ -142,14 +119,14 @@ if (count Achilles_var_excludedFactions > 0 or Achilles_var_moduleTreeCollapse) 
 	];
 };
 
-//collapse unit trees
+// Create empty unit tree: Collapse
 if (Achilles_var_moduleTreeCollapse) then
 {
 	{
-		private _tree_ctrl = _display displayCtrl _x;
-		for "_i" from 0 to ((_tree_ctrl tvCount []) - 1) do
+		private _treeCtrl = _display displayCtrl _x;
+		for "_i" from 0 to ((_treeCtrl tvCount []) - 1) do
 		{
-			_tree_ctrl tvCollapse [_i];
+			_treeCtrl tvCollapse [_i];
 		};
 	} forEach
 	[
@@ -157,19 +134,19 @@ if (Achilles_var_moduleTreeCollapse) then
 	];
 };
 
-//collapse group trees or remove faction
+// Create group trees: Filter and collapse
 {
-	private _tree_ctrl = _display displayCtrl _x;
-	for "_i" from ((_tree_ctrl tvCount [0]) - 1) to 0 step -1 do
+	private _treeCtrl = _display displayCtrl _x;
+	for "_i" from ((_treeCtrl tvCount [0]) - 1) to 0 step -1 do
 	{
 		private _path = [0,_i];
-		private _faction_name = _tree_ctrl tvText _path;
-		if (_faction_name in Achilles_var_excludedFactions) then
+		private _factionName = _treeCtrl tvText _path;
+		if (_factionName in Achilles_var_excludedFactions) then
 		{
-			_tree_ctrl tvDelete _path;
+			_treeCtrl tvDelete _path;
 		} else
 		{
-			_tree_ctrl tvCollapse _path;
+			_treeCtrl tvCollapse _path;
 		};
 	};
 } forEach
@@ -179,12 +156,12 @@ if (Achilles_var_moduleTreeCollapse) then
 	IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_GUER
 ];
 
-//collapse group trees
+// Create CIV and empty groups: Collapse
 {
-	private _tree_ctrl = _display displayCtrl _x;
-	for "_i" from 0 to ((_tree_ctrl tvCount [0]) - 1) do
+	private _treeCtrl = _display displayCtrl _x;
+	for "_i" from 0 to ((_treeCtrl tvCount [0]) - 1) do
 	{
-		_tree_ctrl tvCollapse [0,_i];
+		_treeCtrl tvCollapse [0,_i];
 	};
 } forEach
 [
@@ -195,20 +172,20 @@ if (Achilles_var_moduleTreeCollapse) then
 // Add DLC icons to empty objects to remind player which he can place for non-apex users.
 if (Achilles_var_moduleTreeDLC) then
 {
-	private _tree_ctrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY;
-	for "_i" from 0 to ((_tree_ctrl tvCount []) - 1) do
+	private _treeCtrl = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY;
+	for "_i" from 0 to ((_treeCtrl tvCount []) - 1) do
 	{
-		for "_j" from 0 to ((_tree_ctrl tvCount [_i]) - 1) do
+		for "_j" from 0 to ((_treeCtrl tvCount [_i]) - 1) do
 		{
-			for "_k" from 0 to ((_tree_ctrl tvCount [_i,_j]) - 1) do
+			for "_k" from 0 to ((_treeCtrl tvCount [_i,_j]) - 1) do
 			{
 				private _path = [_i,_j,_k];
-				private _moduleClassName = _tree_ctrl tvData _path;
+				private _moduleClassName = _treeCtrl tvData _path;
 				private _dlc = [(configFile >> "CfgVehicles" >> _moduleClassName), "dlc", ""] call BIS_fnc_returnConfigEntry;
 				private _addonIcon = [(configFile >> "CfgMods" >> _dlc), "logoSmall", ""] call BIS_fnc_returnConfigEntry;
 				if (_addonIcon != "") then
 				{
-					_tree_ctrl tvSetPictureRight [_path, _addonIcon];
+					_treeCtrl tvSetPictureRight [_path, _addonIcon];
 				};
 			};
 		};

--- a/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onModuleTreeLoad.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/eventHandler/fn_onModuleTreeLoad.sqf
@@ -30,65 +30,61 @@ for "_i" from 0 to ((_moduleTreeCtrl tvCount []) - 1) do
 	_categoryList pushBack (_moduleTreeCtrl tvText [_i]);
 };
 
-if !(missionNamespace getVariable ["Achilles_var_missionIsLoadedFromSafe", false]) then
+// Add achilles modules
 {
-	// Add achilles modules
+	private _moduleClass = _x;
+	private _moduleCfg = configFile >> "cfgVehicles" >> _moduleClass;
+	private _moduleName = getText (_moduleCfg >> "displayName");
+	private _moduleIcon = getText (_moduleCfg >> "portrait");
+	private _categoryClass = getText (_moduleCfg >> "category");
+	private _categoryName = getText (configFile >> "CfgFactionClasses" >> _categoryClass >> "displayName");
+	private _dlc = getText (_moduleCfg >> "dlc");
+	private _addonIcon = getText (configFile >> "CfgMods" >> _dlc >> "logoSmall");
+	_categoryList =
+	[
+		_moduleTreeCtrl,
+		_categoryList,
+		_categoryName,
+		_moduleName,
+		_moduleClass,
+		0,
+		_moduleIcon,
+		_addonIcon
+	] call Achilles_fnc_appendToModuleTree;
+} forEach Achilles_var_availableModuleClasses;
+
+// Add custom modules
+if (!isNil "Ares_Custom_Modules") then
+{
 	{
-		private _moduleClass = _x;
-		private _moduleCfg = configFile >> "cfgVehicles" >> _moduleClass;
-		private _moduleName = getText (_moduleCfg >> "displayName");
-		private _moduleIcon = getText (_moduleCfg >> "portrait");
-		private _categoryClass = getText (_moduleCfg >> "category");
-		private _categoryName = getText (configFile >> "CfgFactionClasses" >> _categoryClass >> "displayName");
-		private _dlc = getText (_moduleCfg >> "dlc");
-		private _addonIcon = getText (configFile >> "CfgMods" >> _dlc >> "logoSmall");
+		_x params
+		[
+			"_categoryName",
+			"_moduleDisplayName"
+		];
+		private _moduleClassName = format ["Ares_Module_User_Defined_%1", _forEachIndex];
+
 		_categoryList =
 		[
 			_moduleTreeCtrl,
 			_categoryList,
 			_categoryName,
-			_moduleName,
-			_moduleClass,
-			0,
-			_moduleIcon,
-			_addonIcon
+			_moduleDisplayName,
+			_moduleClassName
 		] call Achilles_fnc_appendToModuleTree;
-	} forEach Achilles_var_availableModuleClasses;
-	systemChat str [Achilles_var_availableModuleClasses, "Achilles_var_availableModuleClasses"];
+	} forEach Ares_Custom_Modules;
+};
 
-	// Add custom modules
-	if (!isNil "Ares_Custom_Modules") then
-	{
-		{
-			_x params
-			[
-				"_categoryName",
-				"_moduleDisplayName"
-			];
-			private _moduleClassName = format ["Ares_Module_User_Defined_%1", _forEachIndex];
-
-			_categoryList =
-			[
-				_moduleTreeCtrl,
-				_categoryList,
-				_categoryName,
-				_moduleDisplayName,
-				_moduleClassName
-			] call Achilles_fnc_appendToModuleTree;
-		} forEach Ares_Custom_Modules;
-	};
-
-	//Sort category and module list
-	_moduleTreeCtrl tvSort [[], false];
-	for "_i" from 0 to ((_moduleTreeCtrl tvCount []) - 1) do
-	{
-		_moduleTreeCtrl tvSort [[_i], false];
-	};
+//Sort category and module list
+_moduleTreeCtrl tvSort [[], false];
+for "_i" from 0 to ((_moduleTreeCtrl tvCount []) - 1) do
+{
+	_moduleTreeCtrl tvSort [[_i], false];
 };
 
 // Set module category list for 
-_category_list sort true;
-Ares_category_list = _category_list;
+_categoryList sort true;
+Ares_category_list = _categoryList;
 
 // Create unit trees: Filter and collapse
 if (count Achilles_var_excludedFactions > 0 or Achilles_var_moduleTreeCollapse) then


### PR DESCRIPTION
**When merged this pull request will:**
- Allow specifying which Achilles modules are available and which are not via CBA settings.
- Thus resolves #259.
- Revise the Achilles init by using mainly unscheduled environment and get rid of the module adding workaround by adding the available modules manually.
- Thus fix the double loading of the curator interface.
- Thus fix the issue that Achilles modules disappeared after loading a mission from a save.
- Revise the faction filter by showing the faction's side in the entry and sorting the entries alphabetically.

