### PR TITLE
Do not kill curators and logics

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_exit.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_exit.sqf
@@ -16,7 +16,7 @@
 	
 	Exampes:
 		(begin example)
-		[] call Achilles_fnc_switchUnit_end;
+		[] call Achilles_fnc_switchUnit_exit;
 		(end)
 */
 

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_exit.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_exit.sqf
@@ -1,17 +1,31 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// AUTHOR: 			Kex
-// DATE: 			6/6/17
-// VERSION: 		AMAE001
-// DESCRIPTION:		terminates "Achilles_fnc_switchUnit_start".
-//
-// ARGUMENTS:		nothing
-//
-// RETURNS:			nothing
-//
-// Example:			[] call Achilles_fnc_switchUnit_exit;
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+	Function:
+		Achilles_fnc_switchUnit_exit
+	
+	Authors:
+		Kex
+	
+	Description:
+		terminates "Achilles_fnc_switchUnit_start"
+	
+	Parameters:
+		_unitDies	- <BOOLEAN> [false] True if the unit dies after the exit.
+	
+	Returns:
+		nothing
+	
+	Exampes:
+		(begin example)
+		[] call Achilles_fnc_switchUnit_end;
+		(end)
+*/
 
 #include "\A3\ui_f_curator\ui\defineResinclDesign.inc"
+
+params
+[
+	["_unitDies", false, [false]]
+];
 
 private _unit = bis_fnc_moduleRemoteControl_unit;
 if (isNull _unit) exitWith {bis_fnc_moduleRemoteControl_unit = nil};
@@ -52,3 +66,4 @@ ctrlMapAnimCommit _curatorMapCtrl;
 _unit addGoggles _goggles;
 _unit setVariable ["Achilles_var_switchUnit_data", nil, true];
 bis_fnc_moduleRemoteControl_unit = nil;
+if (_unitDies) then {_unit setDamage 1};

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_start.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/selectUnit/fn_switchUnit_start.sqf
@@ -1,15 +1,26 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// AUTHOR: 			Kex
-// DATE: 			6/19/17
-// VERSION: 		AMAE003
-// DESCRIPTION:		application of "selectPlayer" script command.
-//
-// ARGUMENTS:		0: OBJECT - Unit to switch to.
-//
-// RETURNS:			nothing
-//
-// Example:			[_unit] call Achilles_fnc_switchUnit_start;
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+	Function:
+		Achilles_fnc_switchUnit_start
+	
+	Authors:
+		Kex
+	
+	Description:
+		Switches the player's unit via the "selectPlayer" script command
+		The player will switch back to his old unit when Achilles_fnc_switchUnit_end is executed
+		Achilles_fnc_switchUnit_end is executed automatically when the unit dies or is unconscious
+	
+	Parameters:
+		_unit	- <OBJECT> The unit to be switched to.
+	
+	Returns:
+		nothing
+	
+	Exampes:
+		(begin example)
+		[_unit] call Achilles_fnc_switchUnit_start;
+		(end)
+*/
 
 private _error = "";
 private _unit = effectiveCommander (param [0]);
@@ -62,7 +73,9 @@ private _eh_id = _unit addEventHandler ["HandleDamage",
 	{
 		if (_selection in ["","body","head"]) then
 		{
-			[] call Achilles_fnc_switchUnit_exit;
+			// Handle Achilles revive from ZGM Achilles missions
+			private _unitDies = [true, false] select (_unit getVariable ["Achilles_var_revive_initialized", false]);
+			[_unitDies] call Achilles_fnc_switchUnit_exit;
 		};
 		_handler = 0.999;
 	};

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
@@ -49,6 +49,7 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 				"_destructionRate"
 			];
 			sleep 5;
+			private _curatorPlayers = [] call BIS_fnc_listCuratorPlayers;
 			// big destruction
 			if (_destructionRadius > 0 && _destructionRate > 0) then
 			{
@@ -61,8 +62,8 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 					private _currentArrayLength = _numberOfObjects - _idxStart - 1; 
 					_currentArrayLength = [_currentArrayLength, _destructionRate] select (_currentArrayLength > _destructionRate);
 					{
-						// Do not kill HCs and curators.
-						if (isNull getAssignedCuratorLogic _x && !(_x isKindOf "HeadlessClient_F") && isNil {_x getVariable ["Achilles_var_switchUnit_data", nil]}) then
+						// Do not kill logics, HCs and curators.
+						if (!(_x isKindOf "Logic") && !(_x in _curatorPlayers) && !(_x isKindOf "HeadlessClient_F") && isNil {_x getVariable ["Achilles_var_switchUnit_data", nil]}) then
 						{
 							_x setDamage 1;
 						};

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
@@ -63,9 +63,16 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 					_currentArrayLength = [_currentArrayLength, _destructionRate] select (_currentArrayLength > _destructionRate);
 					{
 						// Do not kill logics, HCs and curators.
-						if (!(_x isKindOf "Logic") && !(_x in _curatorPlayers) && !(_x isKindOf "HeadlessClient_F") && isNil {_x getVariable ["Achilles_var_switchUnit_data", nil]}) then
+						if (!(_x isKindOf "Logic") && !(_x in _curatorPlayers) && !(_x isKindOf "HeadlessClient_F")) then
 						{
-							_x setDamage 1;
+							if (isNil {_x getVariable ["Achilles_var_switchUnit_data", nil]}) then
+							{
+								_x setDamage 1;
+							}
+							else
+							{
+								[true] remoteExecCall ["Achilles_fnc_switchUnit_end", owner _x];
+							};
 						};
 					} forEach (_objects  select [_idxStart , _currentArrayLength]);
 					sleep 1;

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
@@ -71,7 +71,7 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 							}
 							else
 							{
-								[true] remoteExecCall ["Achilles_fnc_switchUnit_end", owner _x];
+								[true] remoteExecCall ["Achilles_fnc_switchUnit_exit", owner _x];
 							};
 						};
 					} forEach (_objects  select [_idxStart , _currentArrayLength]);

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/FireSupport/functions/fn_ModuleFireSupportNuke.sqf
@@ -49,7 +49,6 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 				"_destructionRate"
 			];
 			sleep 5;
-			private _curatorPlayers = [] call BIS_fnc_listCuratorPlayers;
 			// big destruction
 			if (_destructionRadius > 0 && _destructionRate > 0) then
 			{
@@ -62,8 +61,8 @@ _doColorCorrection = _doColorCorrection isEqualTo 0;
 					private _currentArrayLength = _numberOfObjects - _idxStart - 1; 
 					_currentArrayLength = [_currentArrayLength, _destructionRate] select (_currentArrayLength > _destructionRate);
 					{
-						// Do not kill logics, HCs and curators.
-						if (!(_x isKindOf "Logic") && !(_x in _curatorPlayers) && !(_x isKindOf "HeadlessClient_F")) then
+						// Do not kill "invincible" units, logics, HCs and virtual curators.
+						if ((isDamageAllowed _x) && !(_x isKindOf "Logic") && !(_x isKindOf "VirtualMan_F")) then
 						{
 							if (isNil {_x getVariable ["Achilles_var_switchUnit_data", nil]}) then
 							{

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Objects/functions/fn_ModuleObjectsMakeInvincible.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Objects/functions/fn_ModuleObjectsMakeInvincible.sqf
@@ -34,20 +34,10 @@ if (_objects isEqualTo []) exitWith {[localize "STR_AMAE_NO_OBJECT_SELECTED"] ca
 
 {
 	private _object = _x;
-	if (local _object) then
+	[_object, _allowDamage] remoteExecCall ["allowDamage"];
+	if (_includeCrew) then
 	{
-		_object allowDamage _allowDamage;
-		if (_includeCrew) then
-		{
-			{_x allowDamage _allowDamage} forEach crew _object;
-		};
-	} else
-	{
-		[_object,_allowDamage] remoteExecCall ["allowDamage",_object];
-		if (_includeCrew) then
-		{
-			[_x,_allowDamage] remoteExecCall ["allowDamage",crew _object];
-		};
+		{[_x, _allowDamage] remoteExecCall ["allowDamage"]} forEach crew _object;
 	};
 } forEach _objects;
 

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusVisibility.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusVisibility.sqf
@@ -27,7 +27,7 @@ private _curatorLogic = getAssignedCuratorLogic player;
 if (_invisible and !(isObjectHidden player)) then
 {
 	[player, true] remoteExecCall ["hideObjectGlobal",2];
-	player allowDamage false;
+	[player, false] remoteExecCall ["allowDamage"];
 	player setCaptive true;
 	_curatorLogic setVariable ["showNotification", true];
 
@@ -43,7 +43,7 @@ else
 	if (!_invisible and (isObjectHidden player)) then
 	{
 		[player, false] remoteExecCall ["hideObjectGlobal",2];
-		player allowDamage true;
+		[player, true] remoteExecCall ["allowDamage"];
 		player setCaptive false;
 		_curatorLogic setVariable ["showNotification", false];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Resolves #376
- Switched units and a Zeuses that are not invincible, not virtual and not hidden are now killed.
- Fix the issue that units don't get killed immediately after exiting the switch unit feature.
- Fix the issue in the `make invincible` module that units are no longer invincible when their locality changes.
- Fix the issue in the `make invincible` module that non-local crew members are not invincible.