### PR TITLE
Make Achilles_fnc_getWeaponsMuzzlesMagazines case insensitive regarding magazines

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_getWeaponsMuzzlesMagazines.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_getWeaponsMuzzlesMagazines.sqf
@@ -13,7 +13,7 @@
 // Example:			_weaponsToFire = [_unit] call Achilles_fnc_getWeaponsMuzzlesMagazines;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define BLACKLIST_WEAPONS ["FakeHorn", "AmbulanceHorn", "TruckHorn", "CarHorn", "SportCarHorn", "BikeHorn", "TruckHorn2", "TruckHorn3", "SmokeLauncher"]
+#define BLACKLIST_WEAPONS ["fakehorn", "ambulancehorn", "truckhorn", "carhorn", "sportcarhorn", "bikehorn", "truckhorn2", "truckhorn3", "smokelauncher"]
 
 params [["_unit", objNull, [objNull]]];
 
@@ -22,26 +22,26 @@ if (_unit isKindOf "Man") then
 {
 	// if unit is a soldier
 	// get all available muzzles for the unit's primary weapon
-	private _weapon = primaryWeapon _unit;
-	private _availableMagazines = magazines _unit;
+	private _weapon = toLower primaryWeapon _unit;
+	private _availableMagazines = (magazines _unit) apply {toLower _x};
 	if !(_weapon isEqualTo "") then
 	{
 		// get all muzzles for the weapon
 		private _muzzleArray = [];
 		{
-			private _muzzle = _x;
+			private _muzzle = toLower _x;
 			// filter the muzzle "SAFE" found in RHS weapon configs
-			if (_muzzle != "SAFE") then
+			if (_muzzle != "safe") then
 			{
 				// get the available magazines
 				private _magazines = [];
 				if (_muzzle == "this") then
 				{
-					_magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") arrayIntersect _availableMagazines;
+					_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
 				}
 				else
 				{
-					_magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") arrayIntersect _availableMagazines;
+					_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
 				};
 				// filter smoke shells
 				_magazines = _magazines select {(toLower getText (configFile >> "CfgMagazines" >> _x >> "displayName") find "smoke") isEqualTo -1};
@@ -63,14 +63,14 @@ else
 	private _turrets = [[-1]] + (allTurrets _unit);
 	{
 		private _turretPath = _x;
-		private _availableMagazines = _unit magazinesTurret _turretPath;
+		private _availableMagazines = (_unit magazinesTurret _turretPath) apply {toLower _x};
 		// only consider occupied turrets
 		if (not isNull (_unit turretUnit _turretPath)) then
 		{
 			// for available weapons
 			private _weaponArray = [];
 			{
-				private _weapon = _x;
+				private _weapon = toLower _x;
 				// don't consider blacklisted weapons
 				if !(_weapon isEqualTo "" || _weapon in BLACKLIST_WEAPONS) then
 				{
@@ -78,15 +78,15 @@ else
 					private _muzzleArray = [];
 					{
 						// get the available magazines
-						private _muzzle = _x;
+						private _muzzle = toLower _x;
 						private _magazines = [];
 						if (_muzzle == "this") then
 						{
-							_magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") arrayIntersect _availableMagazines;
+							_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
 						}
 						else
 						{
-							_magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") arrayIntersect _availableMagazines;
+							_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
 						};
 						if !(_magazines isEqualTo []) then
 						{

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_getWeaponsMuzzlesMagazines.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_getWeaponsMuzzlesMagazines.sqf
@@ -13,7 +13,7 @@
 // Example:			_weaponsToFire = [_unit] call Achilles_fnc_getWeaponsMuzzlesMagazines;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define BLACKLIST_WEAPONS ["fakehorn", "ambulancehorn", "truckhorn", "carhorn", "sportcarhorn", "bikehorn", "truckhorn2", "truckhorn3", "smokelauncher"]
+#define BLACKLIST_WEAPONS ["FakeHorn", "AmbulanceHorn", "TruckHorn", "CarHorn", "SportCarHorn", "BikeHorn", "TruckHorn2", "TruckHorn3", "SmokeLauncher"]
 
 params [["_unit", objNull, [objNull]]];
 
@@ -22,26 +22,26 @@ if (_unit isKindOf "Man") then
 {
 	// if unit is a soldier
 	// get all available muzzles for the unit's primary weapon
-	private _weapon = toLower primaryWeapon _unit;
+	private _weapon = primaryWeapon _unit;
 	private _availableMagazines = (magazines _unit) apply {toLower _x};
 	if !(_weapon isEqualTo "") then
 	{
 		// get all muzzles for the weapon
 		private _muzzleArray = [];
 		{
-			private _muzzle = toLower _x;
+			private _muzzle = _x;
 			// filter the muzzle "SAFE" found in RHS weapon configs
-			if (_muzzle != "safe") then
+			if (_muzzle != "SAFE") then
 			{
 				// get the available magazines
 				private _magazines = [];
 				if (_muzzle == "this") then
 				{
-					_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
+					_magazines = ((getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")) apply {toLower _x}) arrayIntersect _availableMagazines;
 				}
 				else
 				{
-					_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
+					_magazines = ((getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines")) apply {toLower _x}) arrayIntersect _availableMagazines;
 				};
 				// filter smoke shells
 				_magazines = _magazines select {(toLower getText (configFile >> "CfgMagazines" >> _x >> "displayName") find "smoke") isEqualTo -1};
@@ -70,7 +70,7 @@ else
 			// for available weapons
 			private _weaponArray = [];
 			{
-				private _weapon = toLower _x;
+				private _weapon = _x;
 				// don't consider blacklisted weapons
 				if !(_weapon isEqualTo "" || _weapon in BLACKLIST_WEAPONS) then
 				{
@@ -78,15 +78,15 @@ else
 					private _muzzleArray = [];
 					{
 						// get the available magazines
-						private _muzzle = toLower _x;
+						private _muzzle = _x;
 						private _magazines = [];
 						if (_muzzle == "this") then
 						{
-							_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
+							_magazines = ((getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")) apply {toLower _x}) arrayIntersect _availableMagazines;
 						}
 						else
 						{
-							_magazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines") apply {toLower _x}) arrayIntersect _availableMagazines;
+							_magazines = ((getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "magazines")) apply {toLower _x}) arrayIntersect _availableMagazines;
 						};
 						if !(_magazines isEqualTo []) then
 						{


### PR DESCRIPTION
**When merged this pull request will:**
- Get Achilles_fnc_getWeaponsMuzzlesMagazines working even if the capitalization of config magazines and `magazines` respective `magazinesTurret` don't match.
- Thus resolve the issue that the suppressive fire module could not be applied to the vanilla static GMG turret.