### PR TITLE
Slow down burst and semi-auto suppressive fire rates

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/features/fn_SuppressiveFire.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/features/fn_SuppressiveFire.sqf
@@ -230,7 +230,8 @@ if (_fireModeIndex == 3) then
 		_gunner setUnitPos (["DOWN","MIDDLE","UP"] select _stanceIndex);
 		// select muzzle and the corresponding turret
 		// get fire mode parameters
-		private _params = [[10,0],[3,0.7],[1,0.9],[10,0]] select _fireModeIndex;
+        // todo: make this configurable from the gui
+		private _params = [[10,0],[3,3],[1,3],[10,0]] select _fireModeIndex;
 		_params params ["_repeatFireCount", "_ceaseFireTime"];
 		// move gunner to a new group
 		private _new_group = createGroup (side _gunner);

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/features/fn_SuppressiveFire.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/features/fn_SuppressiveFire.sqf
@@ -299,7 +299,7 @@ if (_fireModeIndex == 3) then
 			// cease the fire (for semi-auto and burst)
 			if (_ceaseFireTime > 0) then
 			{
-				sleep random [_ceaseFireTime-0.3,_ceaseFireTime,_ceaseFireTime+0.3];
+				sleep random [_ceaseFireTime-1,_ceaseFireTime,_ceaseFireTime+1];
 			};
 			if (not isNull _vehicle) then
 			{


### PR DESCRIPTION
**When merged this pull request will:**
- Increase the pause between firing to 3+/-1 seconds for burst and semi-auto fire rates

This is what the British Army use, I believe, and generally seems more sane to my ears.