### PR TITLE
Sort music alphabetically and resume last track on re-open

### DIFF
--- a/@AresModAchillesExpansion/addons/ui_f/scripts/RscAttributeMusic.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/scripts/RscAttributeMusic.sqf
@@ -22,16 +22,16 @@ switch _mode do {
 			private _name = gettext (_x >> "name");
 			private _tvClass = _musicClasses find (tolower gettext (_x >> "musicClass"));
 			if (_name != "" && _tvClass >= 0) then {
-				private _duration = getnumber (_x >> "duration");
-				private _durationText = [_duration / 60,"HH:MM"] call bis_fnc_timetostring;
-				private _tvMusic = _ctrlValue tvadd [[_tvClass],format ["(%2) %1",_name,_durationText]];
-				_ctrlValue tvsetdata [[_tvClass,_tvMusic],configname _x];
-				_ctrlValue tvsetvalue [[_tvClass,_tvMusic],_duration];
+				private _duration = getNumber (_x >> "duration");
+				private _durationText = [_duration / 60, "HH:MM"] call BIS_fnc_timeToString;
+
+				private _tvMusic = _ctrlValue tvAdd [[_tvClass], format ["%1 (%2)", _name, _durationText]];
+				_ctrlValue tvSetData [[_tvClass, _tvMusic], configName _x];
 			};
-		} foreach (((configfile >> "cfgMusic") call bis_fnc_returnchildren) +  ((missionConfigFile >> "cfgMusic") call bis_fnc_returnchildren));
+		} foreach (((configfile >> "cfgMusic") call bis_fnc_returnchildren) + ((missionConfigFile >> "cfgMusic") call bis_fnc_returnchildren));
 
 		for "_i" from 0 to (count _musicClasses - 1) do {
-			_ctrlValue tvsortbyvalue [[_i],true];
+			_ctrlValue tvSort [[_i], false];
 		};
 
 		_ctrlValue tvsetcursel (uinamespace getvariable ["RscAttributeMusic_selected",[]]);
@@ -41,7 +41,7 @@ switch _mode do {
 		private _display = _params select 0;
 		private _ctrlValue = _display displayctrl IDC_RSCATTRIBUTEMUSIC_VALUE;
 		private _music = _ctrlValue tvdata tvcursel _ctrlValue;
-		//playmusic _music;
+
 		_unit setvariable ["RscAttributeMusic",_music,true];
 	};
 	case "onUnload": {

--- a/@AresModAchillesExpansion/addons/ui_f/scripts/RscAttributeMusic.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/scripts/RscAttributeMusic.sqf
@@ -43,10 +43,29 @@ switch _mode do {
 		private _music = _ctrlValue tvdata tvcursel _ctrlValue;
 
 		_unit setvariable ["RscAttributeMusic",_music,true];
+		uiNamespace setVariable ["RscAttributeMusic_playing", [_music, diag_tickTime]];
 	};
 	case "onUnload": {
-		if (isnil {_unit getvariable "RscAttributeMusic"}) then {
-			playmusic "";
+		// If music is already playing and no new music was selected
+		if (! isNil {uiNamespace getVariable "RscAttributeMusic_playing"} && isNil {_unit getVariable "RscAttributeMusic"}) exitWith {
+			private _musicArray = uiNamespace getVariable "RscAttributeMusic_playing";
+			_musicArray params ["_classname", "_startTime"];
+			
+			private _playTime = diag_tickTime - _startTime;
+			private _duration = [_classname, "duration"] call CBA_fnc_getMusicData;
+
+			// If is still in the track's sound boundaries
+			if (_duration > _playTime) exitWith {
+				[_classname, _playTime, true] call CBA_fnc_playMusic;
+			};
+
+			uiNamespace setVariable ["RscAttributeMusic_playing", nil];
+			playMusic "";
+		};
+
+		if (isnil {_unit getvariable "RscAttributeMusic"}) exitWith {
+			playMusic "";
+			_unit setVariable ["RscAttributeMusic_playing", nil];
 		};
 	};
 	case "treeSelChanged": {


### PR DESCRIPTION
**When merged this pull request will:**
- Sort music alphabetically
  - However, to achieve this you need to change the formatting of the track so it currently results in `<Track name> (HH:MM)`
- Add a feature that resumes the last playing track if the module was reopened and nothing was selected (and the track is still in its length boundaries)

![GIF demonstration](https://user-images.githubusercontent.com/1590711/57152535-71251880-6ddc-11e9-8002-29d3cddfa393.gif)